### PR TITLE
remove quotation marks of column names in sql server queries

### DIFF
--- a/inst/sql/sql_server/field_cdm_datatype.sql
+++ b/inst/sql/sql_server/field_cdm_datatype.sql
@@ -17,12 +17,12 @@ FROM
 	SELECT COUNT(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.* 
 		  FROM @cdmDatabaseSchema.@cdmTableName
 		 WHERE ISNUMERIC(@cdmTableName.@cdmFieldName) = 0
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_cdm_field.sql
+++ b/inst/sql/sql_server/field_cdm_field.sql
@@ -16,14 +16,14 @@ FROM
 (
   select num_violated_rows from
   (
-    select 
-      case when count("@cdmFieldName") = 0 then 0
+    select
+      case when count(@cdmFieldName) = 0 then 0
       else 0
     end as num_violated_rows
     from @cdmDatabaseSchema.@cdmTableName
   ) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT 1 as num_rows
 ) denominator
 ;

--- a/inst/sql/sql_server/field_concept_record_completeness.sql
+++ b/inst/sql/sql_server/field_concept_record_completeness.sql
@@ -14,12 +14,12 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.* 
 		FROM @cdmDatabaseSchema.@cdmTableName
 		WHERE @cdmDatabaseSchema.@cdmTableName.@cdmFieldName = 0
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_fk_class.sql
+++ b/inst/sql/sql_server/field_fk_class.sql
@@ -17,14 +17,14 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.* 
 		FROM @cdmDatabaseSchema.@cdmTableName
-		LEFT JOIN @cdmDatabaseSchema.CONCEPT 
+		LEFT JOIN @cdmDatabaseSchema.CONCEPT
 		ON @cdmTableName.@cdmFieldName = CONCEPT.CONCEPT_ID
-        WHERE CONCEPT.CONCEPT_ID != 0 AND (CONCEPT.CONCEPT_CLASS_ID != '@fkClass') 
+        WHERE CONCEPT.CONCEPT_ID != 0 AND (CONCEPT.CONCEPT_CLASS_ID != '@fkClass')
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_fk_domain.sql
+++ b/inst/sql/sql_server/field_fk_domain.sql
@@ -17,15 +17,15 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, t.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, t.* 
 		  FROM @cdmDatabaseSchema.@cdmTableName t
 		  LEFT JOIN @cdmDatabaseSchema.CONCEPT c
 		    ON t.@cdmFieldName = c.CONCEPT_ID
 		 WHERE c.CONCEPT_ID != 0 AND c.DOMAIN_ID != '@fkDomain'
-		  
+
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_is_not_nullable.sql
+++ b/inst/sql/sql_server/field_is_not_nullable.sql
@@ -17,12 +17,12 @@ FROM
 	SELECT COUNT(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.* 
 		  FROM @cdmDatabaseSchema.@cdmTableName
 		 WHERE @cdmTableName.@cdmFieldName IS NULL
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_is_primary_key.sql
+++ b/inst/sql/sql_server/field_is_primary_key.sql
@@ -17,15 +17,15 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.* 
 		  FROM @cdmDatabaseSchema.@cdmTableName
-		 WHERE @cdmTableName.@cdmFieldName IN ( SELECT @cdmTableName.@cdmFieldName 
+		 WHERE @cdmTableName.@cdmFieldName IN ( SELECT @cdmTableName.@cdmFieldName
 		                                          FROM @cdmDatabaseSchema.@cdmTableName
 												 GROUP BY @cdmTableName.@cdmFieldName
-												HAVING COUNT_BIG(*) > 1 ) 
+												HAVING COUNT_BIG(*) > 1 )
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_is_standard_valid_concept.sql
+++ b/inst/sql/sql_server/field_is_standard_valid_concept.sql
@@ -16,13 +16,13 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, t.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, t.* 
 		  FROM @cdmDatabaseSchema.@cdmTableName t
-		  join @cdmDatabaseSchema.CONCEPT c ON t.@cdmFieldName = c.CONCEPT_ID 
-		  WHERE c.CONCEPT_ID != 0 AND (c.STANDARD_CONCEPT != 'S' OR c.INVALID_REASON IS NOT NULL ) 
+		  join @cdmDatabaseSchema.CONCEPT c ON t.@cdmFieldName = c.CONCEPT_ID
+		  WHERE c.CONCEPT_ID != 0 AND (c.STANDARD_CONCEPT != 'S' OR c.INVALID_REASON IS NOT NULL )
   ) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_measure_value_completeness.sql
+++ b/inst/sql/sql_server/field_measure_value_completeness.sql
@@ -16,12 +16,12 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.* 
 		FROM @cdmDatabaseSchema.@cdmTableName
 		WHERE @cdmDatabaseSchema.@cdmTableName.@cdmFieldName IS NULL
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/field_plausible_during_life.sql
+++ b/inst/sql/sql_server/field_plausible_during_life.sql
@@ -16,7 +16,7 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.*
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.*
     from @cdmDatabaseSchema.@cdmTableName
     join @cdmDatabaseSchema.death on @cdmDatabaseSchema.@cdmTableName.person_id = @cdmDatabaseSchema.death.person_id
     where @cdmFieldName > death_date

--- a/inst/sql/sql_server/field_plausible_temporal_after.sql
+++ b/inst/sql/sql_server/field_plausible_temporal_after.sql
@@ -17,7 +17,7 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.*
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.*
     from @cdmDatabaseSchema.@cdmTableName
     {@cdmDatabaseSchema.@cdmTableName != @cdmDatabaseSchema.@plausibleTemporalAfterTableName}?{
 		join @cdmDatabaseSchema.@plausibleTemporalAfterTableName

--- a/inst/sql/sql_server/field_plausible_value_high.sql
+++ b/inst/sql/sql_server/field_plausible_value_high.sql
@@ -16,7 +16,7 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.*
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.*
     from @cdmDatabaseSchema.@cdmTableName
     where @cdmFieldName > @plausibleValueHigh
 	) violated_rows

--- a/inst/sql/sql_server/field_plausible_value_low.sql
+++ b/inst/sql/sql_server/field_plausible_value_low.sql
@@ -16,7 +16,7 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.*
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.*
 		from @cdmDatabaseSchema.@cdmTableName
     where @cdmFieldName < @plausibleValueLow
 	) violated_rows

--- a/inst/sql/sql_server/field_source_value_completeness.sql
+++ b/inst/sql/sql_server/field_source_value_completeness.sql
@@ -15,12 +15,12 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT DISTINCT '@cdmTableName.@cdmFieldName' AS violating_field, @cdmTableName.@cdmFieldName
+		SELECT DISTINCT @cdmTableName.@cdmFieldName AS violating_field, @cdmTableName.@cdmFieldName
 		FROM @cdmDatabaseSchema.@cdmTableName
 		WHERE @cdmDatabaseSchema.@cdmTableName.@standardConceptFieldName = 0
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(DISTINCT @cdmFieldName) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator

--- a/inst/sql/sql_server/is_foreign_key.sql
+++ b/inst/sql/sql_server/is_foreign_key.sql
@@ -18,14 +18,14 @@ FROM
 	SELECT COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
 	FROM
 	(
-		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, p1.* 
+		SELECT @cdmTableName.@cdmFieldName AS violating_field, p1.* 
 		FROM @cdmDatabaseSchema.@cdmTableName p1
 		LEFT JOIN @cdmDatabaseSchema.@fkTableName f1
 		ON p1.@cdmFieldName = f1.@fkFieldName
-		WHERE f1.@fkFieldName IS NULL AND p1.@cdmFieldName IS NOT NULL 
+		WHERE f1.@fkFieldName IS NULL AND p1.@cdmFieldName IS NOT NULL
 	) violated_rows
 ) violated_row_count,
-( 
+(
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName
 ) denominator


### PR DESCRIPTION
I think errors occur because of quotation marks of column names in sql server queries. So I removed it. 

(only '@field_name' will work, but '@cdmDatabase.@field_name' doesn't work)