### PR TITLE
Fixes #151, reverting back to prior sql

### DIFF
--- a/inst/sql/sql_server/field_cdm_field.sql
+++ b/inst/sql/sql_server/field_cdm_field.sql
@@ -18,7 +18,7 @@ FROM
   select num_violated_rows from
   (
     select
-      case when count_big("@cdmFieldName") > 1 then 1
+      case when count_big("@cdmFieldName") = 0 then 0
       else 0
     end as num_violated_rows
     from @cdmDatabaseSchema.@cdmTableName cdmTable


### PR DESCRIPTION
This commit initially looks weird because it always returns 0, and I actually changed it in the past so that it would sometimes return 1. What happened is that if a table existed with the field but no records the check would incorrectly be labeled a fail. In reality, this query is really a proxy for determining if a field exists. By always returning 0, if it can be resolved, then the check will always pass. If the field in quotes doesn't exist then the check will error out and fail. 