### PR TITLE
Double quotes produce errors in Oracle

### DIFF
--- a/inst/csv/OMOP_CDMv5.2.2_Field_Level.csv
+++ b/inst/csv/OMOP_CDMv5.2.2_Field_Level.csv
@@ -155,7 +155,7 @@ NOTE_NLP,note_nlp_id,Yes,0,,integer,0,,,,Yes,0,,No,,,,,,,,,,,No,,,Yes,0,,No,,,No
 NOTE_NLP,note_id,Yes,0,,integer,0,,,,No,,,Yes,0,,NOTE,NOTE_ID,,,,,,,No,,,Yes,0,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,section_concept_id,No,,,integer,0,,,,No,,,Yes,0,,CONCEPT,CONCEPT_ID,,,,,,,Yes,0,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,snippet,No,,,varchar(250),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
-NOTE_NLP,offset,No,,,varchar(50),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
+NOTE_NLP,'offset',No,,,varchar(50),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,lexical_variant,Yes,0,,varchar(250),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,0,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,note_nlp_concept_id,No,,,integer,0,,,,No,,,Yes,0,,CONCEPT,CONCEPT_ID,,,,,,,Yes,0,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,note_nlp_source_concept_id,No,,,integer,0,,,,No,,,Yes,0,,CONCEPT,CONCEPT_ID,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No

--- a/inst/csv/OMOP_CDMv5.3.1_Field_Level.csv
+++ b/inst/csv/OMOP_CDMv5.3.1_Field_Level.csv
@@ -181,7 +181,7 @@ NOTE_NLP,note_nlp_id,Yes,0,,integer,0,,,,Yes,0,,No,,,,,,,,,,,No,,,Yes,0,,No,,,No
 NOTE_NLP,note_id,Yes,0,,integer,0,,,,No,,,Yes,0,,NOTE,NOTE_ID,,,,,,,No,,,Yes,0,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,section_concept_id,No,,,integer,0,,,,No,,,Yes,0,,CONCEPT,CONCEPT_ID,,,,,,,Yes,0,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,snippet,No,,,varchar(250),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
-NOTE_NLP,offset,No,,,varchar(50),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
+NOTE_NLP,'offset',No,,,varchar(50),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,lexical_variant,Yes,0,,varchar(250),0,,,,No,,,No,,,,,,,,,,,No,,,Yes,0,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,note_nlp_concept_id,No,,,integer,0,,,,No,,,Yes,0,,CONCEPT,CONCEPT_ID,,,,,,,Yes,0,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No
 NOTE_NLP,note_nlp_source_concept_id,No,,,integer,0,,,,No,,,Yes,0,,CONCEPT,CONCEPT_ID,,,,,,,No,,,Yes,100,,No,,,No,,,No,,,,,,,,,,,,,,,No,,,No

--- a/inst/sql/sql_server/field_cdm_field.sql
+++ b/inst/sql/sql_server/field_cdm_field.sql
@@ -18,7 +18,7 @@ FROM
   select num_violated_rows from
   (
     select
-      case when count_big("@cdmFieldName") = 0 then 0
+      case when count_big(@cdmFieldName) = 0 then 0
       else 0
     end as num_violated_rows
     from @cdmDatabaseSchema.@cdmTableName cdmTable


### PR DESCRIPTION
Double quotes are interpreted with an explicit case in Oracle which does not conform with the DDL for v5.3.1 for the OMOP CDM, which results in all conformance checks failing for the `cdmField` checks in Oracle. This PR addresses #162.