### PR TITLE
Closes #105

### DIFF
--- a/inst/sql/sql_server/field_cdm_field.sql
+++ b/inst/sql/sql_server/field_cdm_field.sql
@@ -18,7 +18,7 @@ FROM
   select num_violated_rows from
   (
     select
-      case when count_big("@cdmFieldName") = 0 then 0
+      case when count_big(@cdmFieldName) = 0 then 0
       else 0
     end as num_violated_rows
     from @cdmDatabaseSchema.@cdmTableName cdmTable


### PR DESCRIPTION
Removes quotes from CDM_FIELD check that were causing errors. Tested on Postgresql, Redshift, and PDW.