### PR TITLE
Initial attempt at cleansing via sqlrender

### DIFF
--- a/inst/sql/sql_server/concept_plausible_gender.sql
+++ b/inst/sql/sql_server/concept_plausible_gender.sql
@@ -1,4 +1,3 @@
-
 /*********
 CONCEPT LEVEL check:
 PLAUSIBLE_GENDER - number of records of a given concept which occur in person with implausible gender for that concept
@@ -15,7 +14,25 @@ cohortDatabaseSchema = @cohortDatabaseSchema
 }
 **********/
 
-
+{@CLEANSE} ? {
+	INSERT INTO @cdmDatabaseSchema.@cdmTableName_archive
+		SELECT cdmTable.* 
+		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
+		INNER JOIN @cdmDatabaseSchema.person p
+		ON cdmTable.person_id = p.person_id			
+		WHERE cdmTable.@cdmFieldName = @conceptId
+		AND p.gender_concept_id <> {@plausibleGender == 'Male'} ? {8507} : {8532}; 
+	
+	DELETE FROM @cdmDatabaseSchema.@cdmTableName WHERE cdmTable.@cdmFieldName IN ( 
+		SELECT cdmTable.*@cdmFieldName 
+		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
+		INNER JOIN @cdmDatabaseSchema.person p
+		ON cdmTable.person_id = p.person_id			
+		WHERE cdmTable.@cdmFieldName = @conceptId
+		AND p.gender_concept_id <> {@plausibleGender == 'Male'} ? {8507} : {8532}
+    );	
+}
+{@EXECUTE} ? {
 SELECT num_violated_rows, CASE WHEN denominator.num_rows = 0 THEN 0 ELSE 1.0*num_violated_rows/denominator.num_rows END AS pct_violated_rows, 
   denominator.num_rows as num_denominator_rows
 FROM
@@ -49,5 +66,5 @@ FROM
 	}
 	
 	WHERE @cdmFieldName = @conceptId
-) denominator
-;
+) denominator;
+}


### PR DESCRIPTION
Frank,

Only concept_plausible_gender.sql has been modified in this initial attempt - no R code has changed.  Here's how to test it:

```r
library(SqlRender)

actions <- list(CLEANSE=FALSE, EXECUTE=TRUE) # execute only - Orig behavior
# actions <- list(CLEANSE=TRUE, EXECUTE=TRUE) # Cleanse first, then execute

sql <- SqlRender::readSql("inst/sql/sql_server/concept_plausible_gender.sql")

# Supply some dummy params for verification
renderedSql <- SqlRender::render(
  sql, 
  CLEANSE = actions$CLEANSE, 
  EXECUTE = actions$EXECUTE,
  cdmDatabaseSchema = "cdm_truven_ccae_v0000",
  cdmTableName = "measurement",
  cdmFieldName = "measurement_concept_id",
  conceptId = 99999999,
  plausibleGender = 'Male',
  cohort = FALSE)

# write out to a file for easy viewing
SqlRender::writeSql(renderedSql,"cleansed_concept_plausible_gender.sql")
```

With CLEANSE=FALSE, we should get default concept_plausible_gender.sql file.  With CLEANSE=TRUE, we should get the INSERT + DELETE added to the file.  Let me know how it looks. 