### PR TITLE
Clean header of CSV export in shiny app

### DIFF
--- a/inst/shinyApps/www/js/loadResults.js
+++ b/inst/shinyApps/www/js/loadResults.js
@@ -97,7 +97,22 @@ function loadResults(results) {
         order: [[10, "desc"]],
         buttons: [
             'colvis',
-            'csvHtml5'
+            {
+                extend: 'csv',
+                filename: 'dqd_results',
+                text: 'Export',
+                header: true,
+                exportOptions: {
+                    // All but the first (empty) column
+                    columns: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+                    // Header without drop down options
+                    format: {
+                        header: function(innerHTML, index, node) {
+                            return innerHTML.replace(/<.+/, '').replace(/&nbsp;/g, ' ');
+                        }
+                    }
+                }
+            }
         ],
         data: results.CheckResults,
         initComplete: function () {


### PR DESCRIPTION
### Observed behaviour
The csv export used to contain all the options from the select, like so:

"" | STATUSFAILPASS | TABLECARE_SITECONDITION_ERACONDITION_OCCURRENCECOSTDEVICE_EXPOSUREDOSE_ERADRUG_ERADRUG_EXPOSUREFACT_RELATIONSHIPLOCATIONMEASUREMENTNOTENOTE_NLPOBSERVATIONOBSERVATION_PERIODPAYER_PLAN_PERIODPERSONPROCEDURE_OCCURRENCEPROVIDERSPECIMENVISIT_DETAILVISIT_OCCURRENCE | FIELDADDRESS_1ADDRESS_2ADMITTING_SOURCE_CONCEPT_IDADMITTING_SOURCE_VALUEAMOUNT_ALLOWEDANATOMIC_SITE_CONCEPT_IDANATOMIC_SITE_SOURCE_VALUEBIRTH_DATETIMECARE_SITE_IDCARE_SITE_NAMECARE_SITE_SOURCE_VALUECITYCONDITION_CONCEPT_IDCONDITION_END_DATECONDITION_END_DATETIMECONDITION_ERA_END_DATECONDITION_ERA_IDCONDITION_ERA_START_DATECONDITION_OCCURRENCE_COUNTCONDITION_OCCURRENCE_IDCONDITION_SOURCE_CONCEPT_IDCONDITION_SOURCE_VALUECONDITION_START_DATECONDITION_START_DATETIMECONDITION_STATUS_CONCEPT_IDCONDITION_STATUS_SOURCE_VALUECONDITION_TYPE_CONCEPT_IDCOST_DOMAIN_IDCOST_EVENT_IDCOST_IDCOST_TYPE_CONCEPT_IDCOUNTYCURRENCY_CONCEPT_IDDAYS_SUPPLYDAY_OF_BIRTHDEADEVICE_CONCEPT_IDDEVICE_EXPOSURE_END_DATEDEVICE_EXPOSURE_END_DATETIMEDEVICE_EXPOSURE_IDDEVICE_EXPOSURE_START_DATEDEVICE_EXPOSURE_START_DATETIMEDEVICE_SOURCE_CONCEPT_IDDEVICE_SOURCE_VALUEDEVICE_TYPE_CONCEPT_IDDISCHARGE_TO_CONCEPT_IDDISCHARGE_TO_SOURCE_VALUEDISEASE_STATUS_CONCEPT_IDDISEASE_STATUS_SOURCE_VALUEDOMAIN_CONCEPT_ID_1DOMAIN_CONCEPT_ID_2DOSE_ERA_END_DATEDOSE_ERA_IDDOSE_ERA_START_DATEDOSE_UNIT_SOURCE_VALUEDOSE_VALUEDRG_CONCEPT_IDDRG_SOURCE_VALUEDRUG_CONCEPT_IDDRUG_ERA_END_DATEDRUG_ERA_IDDRUG_ERA_START_DATEDRUG_EXPOSURE_COUNTDRUG_EXPOSURE_END_DATEDRUG_EXPOSURE_END_DATETIMEDRUG_EXPOSURE_IDDRUG_EXPOSURE_START_DATEDRUG_EXPOSURE_START_DATETIMEDRUG_SOURCE_CONCEPT_IDDRUG_SOURCE_VALUEDRUG_TYPE_CONCEPT_IDENCODING_CONCEPT_IDETHNICITY_CONCEPT_IDETHNICITY_SOURCE_CONCEPT_IDETHNICITY_SOURCE_VALUEFACT_ID_1FACT_ID_2FAMILY_SOURCE_VALUEGAP_DAYSGENDER_CONCEPT_IDGENDER_SOURCE_CONCEPT_IDGENDER_SOURCE_VALUELANGUAGE_CONCEPT_IDLEXICAL_VARIANTLOCATION_IDLOCATION_SOURCE_VALUELOT_NUMBERMEASUREMENT_CONCEPT_IDMEASUREMENT_DATEMEASUREMENT_DATETIMEMEASUREMENT_IDMEASUREMENT_SOURCE_CONCEPT_IDMEASUREMENT_SOURCE_VALUEMEASUREMENT_TIMEMEASUREMENT_TYPE_CONCEPT_IDMODIFIER_CONCEPT_IDMODIFIER_SOURCE_VALUEMONTH_OF_BIRTHNLP_DATENLP_DATETIMENLP_SYSTEMNOTE_CLASS_CONCEPT_IDNOTE_DATENOTE_DATETIMENOTE_IDNOTE_NLP_CONCEPT_IDNOTE_NLP_IDNOTE_NLP_SOURCE_CONCEPT_IDNOTE_SOURCE_VALUENOTE_TEXTNOTE_TITLENOTE_TYPE_CONCEPT_IDNPINoneOBSERVATION_CONCEPT_IDOBSERVATION_DATEOBSERVATION_DATETIMEOBSERVATION_IDOBSERVATION_PERIOD_END_DATEOBSERVATION_PERIOD_IDOBSERVATION_PERIOD_START_DATEOBSERVATION_SOURCE_CONCEPT_IDOBSERVATION_SOURCE_VALUEOBSERVATION_TYPE_CONCEPT_IDOFFSETOPERATOR_CONCEPT_IDPAID_BY_PATIENTPAID_BY_PAYERPAID_BY_PRIMARYPAID_DISPENSING_FEEPAID_INGREDIENT_COSTPAID_PATIENT_COINSURANCEPAID_PATIENT_COPAYPAID_PATIENT_DEDUCTIBLEPAYER_CONCEPT_IDPAYER_PLAN_PERIOD_END_DATEPAYER_PLAN_PERIOD_IDPAYER_PLAN_PERIOD_START_DATEPAYER_SOURCE_CONCEPT_IDPAYER_SOURCE_VALUEPERIOD_TYPE_CONCEPT_IDPERSON_IDPERSON_SOURCE_VALUEPLACE_OF_SERVICE_CONCEPT_IDPLACE_OF_SERVICE_SOURCE_VALUEPLAN_CONCEPT_IDPLAN_SOURCE_CONCEPT_IDPLAN_SOURCE_VALUEPRECEDING_VISIT_DETAIL_IDPRECEDING_VISIT_OCCURRENCE_IDPROCEDURE_CONCEPT_IDPROCEDURE_DATEPROCEDURE_DATETIMEPROCEDURE_OCCURRENCE_IDPROCEDURE_SOURCE_CONCEPT_IDPROCEDURE_SOURCE_VALUEPROCEDURE_TYPE_CONCEPT_IDPROVIDER_IDPROVIDER_NAMEPROVIDER_SOURCE_VALUEQUALIFIER_CONCEPT_IDQUALIFIER_SOURCE_VALUEQUANTITYRACE_CONCEPT_IDRACE_SOURCE_CONCEPT_IDRACE_SOURCE_VALUERANGE_HIGHRANGE_LOWREFILLSRELATIONSHIP_CONCEPT_IDREVENUE_CODE_CONCEPT_IDREVENUE_CODE_SOURCE_VALUEROUTE_CONCEPT_IDROUTE_SOURCE_VALUESECTION_CONCEPT_IDSIGSNIPPETSPECIALTY_CONCEPT_IDSPECIALTY_SOURCE_CONCEPT_IDSPECIALTY_SOURCE_VALUESPECIMEN_CONCEPT_IDSPECIMEN_DATESPECIMEN_DATETIMESPECIMEN_IDSPECIMEN_SOURCE_IDSPECIMEN_SOURCE_VALUESPECIMEN_TYPE_CONCEPT_IDSPONSOR_CONCEPT_IDSPONSOR_SOURCE_CONCEPT_IDSPONSOR_SOURCE_VALUESTATESTOP_REASONSTOP_REASON_CONCEPT_IDSTOP_REASON_SOURCE_CONCEPT_IDSTOP_REASON_SOURCE_VALUETERM_EXISTSTERM_MODIFIERSTERM_TEMPORALTOTAL_CHARGETOTAL_COSTTOTAL_PAIDUNIQUE_DEVICE_IDUNIT_CONCEPT_IDUNIT_SOURCE_VALUEVALUE_AS_CONCEPT_IDVALUE_AS_NUMBERVALUE_AS_STRINGVALUE_SOURCE_VALUEVERBATIM_END_DATEVISIT_CONCEPT_IDVISIT_DETAIL_CONCEPT_IDVISIT_DETAIL_END_DATEVISIT_DETAIL_END_DATETIMEVISIT_DETAIL_IDVISIT_DETAIL_PARENT_IDVISIT_DETAIL_SOURCE_CONCEPT_IDVISIT_DETAIL_SOURCE_VALUEVISIT_DETAIL_START_DATEVISIT_DETAIL_START_DATETIMEVISIT_DETAIL_TYPE_CONCEPT_IDVISIT_END_DATEVISIT_END_DATETIMEVISIT_OCCURRENCE_IDVISIT_SOURCE_CONCEPT_IDVISIT_SOURCE_VALUEVISIT_START_DATEVISIT_START_DATETIMEVISIT_TYPE_CONCEPT_IDYEAR_OF_BIRTHZIP | CHECKcdmDatatypecdmFieldfkClassfkDomainisForeignKeyisPrimaryKeyisRequiredmeasurePersonCompletenessmeasureValueCompletenessplausibleDuringLifeplausibleGenderplausibleTemporalAfterplausibleValueHighplausibleValueLowsourceConceptRecordCompletenesssourceValueCompletenessstandardConceptRecordCompleteness | CATEGORYCompletenessConformancePlausibility | SUBCATEGORYAtemporalComputationalNoneRelationalTemporalValue | LEVELCONCEPTFIELDTABLE | NOTESExistsNone | DESCRIPTION | % RECORDS
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --

### Expected behaviour
With this PR, the select options are stripped from the header and the first (empty) column is removed:

STATUS | TABLE | FIELD | CHECK | CATEGORY | SUBCATEGORY | LEVEL | NOTES | DESCRIPTION | % RECORDS
-- | -- | -- | -- | -- | -- | -- | -- | -- | --



