### PR TITLE
add '...' parameter and default parameters to view function

### DIFF
--- a/R/view.R
+++ b/R/view.R
@@ -35,5 +35,5 @@ viewDqDashboard <- function(jsonPath, launch.browser=NULL, display.mode=NULL, ..
       launch.browser=TRUE
   }
 
-  shiny::runApp(appDir = appDir, launch.browser, display.mode, ...)
+  shiny::runApp(appDir = appDir, launch.browser = launch.browser, display.mode = display.mode, ...)
 }

--- a/R/view.R
+++ b/R/view.R
@@ -20,10 +20,20 @@
 #' View DQ Dashboard
 #' 
 #' @param jsonPath       The path to the JSON file produced by  \code{\link{executeDqChecks}}
-#' 
+#' @param ...            Extra parameters for shiny::runApp() like "port" or "host"
+#'
 #' @export
-viewDqDashboard <- function(jsonPath) {
+viewDqDashboard <- function(jsonPath, launch.browser=NULL, display.mode=NULL, ...) {
   Sys.setenv(jsonPath = jsonPath)
   appDir <- system.file("shinyApps", package = "DataQualityDashboard")
-  shiny::runApp(appDir = appDir, display.mode = "normal", launch.browser = TRUE)
+
+  if(is.null(display.mode)){
+      display.mode="normal"
+  }
+
+  if(is.null(launch.browser)){
+      launch.browser=TRUE
+  }
+
+  shiny::runApp(appDir = appDir, launch.browser, display.mode, ...)
 }


### PR DESCRIPTION
To allow users to use other port and host in viewDqDashboard(), I added '...' parameter and make display.mode and launch.browser an additional parameter where default options were set. With these litte change the user can use any parameter of shiny::runApp() function.