### PR TITLE
Add a missing parameter in an execution subroutine in R code

### DIFF
--- a/R/execution.R
+++ b/R/execution.R
@@ -101,7 +101,7 @@
   tryCatch(
     expr = {
       if (singleThreaded) {
-        if (.needsAutoCommit(connection)) {
+        if (.needsAutoCommit(connectionDetails, connection)) {
           rJava::.jcall(connection@jConnection, "V", "setAutoCommit", TRUE)
         }  
       }
@@ -736,7 +736,7 @@ writeJsonResultsToTable <- function(connectionDetails,
   )
 }
 
-.needsAutoCommit <- function(connection) {
+.needsAutoCommit <- function(connectionDetails, connection) {
   autoCommit <- FALSE
   if (!is.null(connection)) {
     if (inherits(connection, "DatabaseConnectorJdbcConnection")) {


### PR DESCRIPTION
`.needsAutoCommit` requires a variable named `connectionDetails` which is not provided by its declaration.
The current PR fixes it with the value created by `executeDqChecks`.

(related to #269 )