### PR TITLE
Fixes #244: Birth_datetime used in plausibleTemporalAfter check

### DIFF
--- a/inst/sql/sql_server/field_plausible_temporal_after.sql
+++ b/inst/sql/sql_server/field_plausible_temporal_after.sql
@@ -31,7 +31,12 @@ FROM
     JOIN @cohortDatabaseSchema.COHORT c 
       ON cdmTable.PERSON_ID = c.SUBJECT_ID
     	AND c.COHORT_DEFINITION_ID = @cohortDefinitionId}
-    WHERE cast(@plausibleTemporalAfterFieldName as date) > cast(cdmTable.@cdmFieldName as date)
+    WHERE 
+    {@cdmDatabaseSchema.@cdmTableName != @cdmDatabaseSchema.@plausibleTemporalAfterTableName}?{
+		COALESCE(CAST(plausibleTable.@plausibleTemporalAfterFieldName AS DATE),CAST(CONCAT(plausibleTable.YEAR_OF_BIRTH,'-06-01') AS DATE)) 
+	}:{
+		CAST(cdmTable.@plausibleTemporalAfterFieldName AS DATE)
+	} > CAST(cdmTable.@cdmFieldName AS DATE)
 	) violated_rows
 ) violated_row_count,
 (

--- a/inst/sql/sql_server/field_plausible_temporal_after.sql
+++ b/inst/sql/sql_server/field_plausible_temporal_after.sql
@@ -32,7 +32,7 @@ FROM
       ON cdmTable.PERSON_ID = c.SUBJECT_ID
     	AND c.COHORT_DEFINITION_ID = @cohortDefinitionId}
     WHERE 
-    {@cdmDatabaseSchema.@cdmTableName != @cdmDatabaseSchema.@plausibleTemporalAfterTableName}?{
+    {'@plausibleTemporalAfterTableName' == 'PERSON'}?{
 		COALESCE(CAST(plausibleTable.@plausibleTemporalAfterFieldName AS DATE),CAST(CONCAT(plausibleTable.YEAR_OF_BIRTH,'-06-01') AS DATE)) 
 	}:{
 		CAST(cdmTable.@plausibleTemporalAfterFieldName AS DATE)


### PR DESCRIPTION
Used conditional SqlRender statements to update field_plausible_temporal_after.sql, so that NULL birth_datetime will use yob-06-01.  Tested successfully on redshift
