### PR TITLE
Domain and Class checks denominator only non-zero concepts

### DIFF
--- a/inst/sql/sql_server/field_fk_class.sql
+++ b/inst/sql/sql_server/field_fk_class.sql
@@ -43,5 +43,6 @@ FROM
     	ON cdmTable.PERSON_ID = c.SUBJECT_ID
     	AND c.COHORT_DEFINITION_ID = @cohortDefinitionId
     	}
+        WHERE cdmTable.@cdmFieldName != 0 
 ) denominator
 ;

--- a/inst/sql/sql_server/field_fk_domain.sql
+++ b/inst/sql/sql_server/field_fk_domain.sql
@@ -44,5 +44,6 @@ FROM
     	ON cdmTable.PERSON_ID = c.SUBJECT_ID
     	AND c.COHORT_DEFINITION_ID = @cohortDefinitionId
     	}
+        WHERE cdmTable.@cdmFieldName != 0 
 ) denominator
 ;


### PR DESCRIPTION
Fixes #309

The idea is that this change will give a more meaningful fail%. However, it might be confusing that the denominator count is different in the same table for different checks. Simplicity/consistency might be preferable. Happy to discuss.

- [ ] also apply for the `FIELD_IS_STANDARD_VALID_CONCEPT` check?