### PR TITLE
Modify CDM Data Type

### DIFF
--- a/inst/sql/sql_server/field_cdm_datatype.sql
+++ b/inst/sql/sql_server/field_cdm_datatype.sql
@@ -20,7 +20,7 @@ FROM
 	(
 		SELECT '@cdmTableName.@cdmFieldName' AS violating_field, cdmTable.* 
 		  FROM @cdmDatabaseSchema.@cdmTableName cdmTable
-		 WHERE ISNUMERIC(abs(cdmTable.@cdmFieldName)) = 0 AND cdmTable.@cdmFieldName IS NOT NULL
+		 WHERE ISNUMERIC(CONCAT(CAST(cdmTable.@cdmFieldName as VARCHAR),'.e0')) = 0 AND cdmTable.@cdmFieldName IS NOT NULL
 	) violated_rows
 ) violated_row_count,
 ( 


### PR DESCRIPTION
Current where clause treats floating point numbers as integers. Consider changing to account for decimals.

**Example:** 

value =1.1

`ISNUMERIC(abs(1.1))`

Actual: 1

Expected: 0