### PR TITLE
Add Release GitHub Action and PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Before you do a pull request, you should always **file an issue** and make sure the package maintainer agrees that it's a problem, and is happy with your basic proposal for fixing it. We don't want you to spend a bunch of time on something that we don't think is a good idea.
+
+Additional requirements for pull requests:
+
+-   Adhere to the [Developer Guidelines](https://ohdsi.github.io/MethodsLibrary/developerGuidelines.html) as well as the [OHDSI Code Style](https://ohdsi.github.io/MethodsLibrary/codeStyle.html).
+
+-   If possible, add unit tests for new functionality you add.
+
+-   Restrict your pull request to solving the issue at hand. Do not try to 'improve' parts of the code that are not related to the issue. If you feel other parts of the code need better organization, create a separate issue for that.
+
+-   Make sure you pass R check without errors and warnings before submitting.
+
+-   Always target the `develop` branch, and make sure you are up-to-date with the develop branch.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Before you do a pull request, you should always **file an issue** and make sure 
 
 Additional requirements for pull requests:
 
--   Adhere to the [Developer Guidelines](https://ohdsi.github.io/MethodsLibrary/developerGuidelines.html) as well as the [OHDSI Code Style](https://ohdsi.github.io/MethodsLibrary/codeStyle.html).
+-   Adhere to the [Developer Guidelines](https://ohdsi.github.io/Hades/developerGuidelines.html) as well as the [OHDSI Code Style](https://ohdsi.github.io/Hades/codeStyle.html).
 
 -   If possible, add unit tests for new functionality you add.
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -126,66 +126,38 @@ jobs:
         run: covr::codecov()
         shell: Rscript {0}
 
-# Release:
-#     needs: R-CMD-Check
+  Release:
+    needs: R-CMD-Check
 
-#     runs-on: macOS-latest
+    runs-on: macOS-latest
 
-#     env:
-#       GH_TOKEN: ${{ github.token }}
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
 
-#     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
 
-#     steps:
+    steps:
 
-#       - uses: actions/checkout@v2
-#         with:
-#           fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-#       - name: Check if version has increased
-#         run: |
-#           echo "new_version="$(perl compare_versions --tag) >> $GITHUB_ENV
-#       - name: Display new version number
-#         if: ${{ env.new_version != '' }}
-#         run: |
-#           echo "${{ env.new_version }}"
-#       - name: Create release
-#         if: ${{ env.new_version != '' }}
-#         uses: actions/create-release@v1
-#         env:
-#           GITHUB_TOKEN: ${{ github.token }}
-#         with:
-#           tag_name: ${{ env.new_version }}
-#           release_name: Release ${{ env.new_version }}
-#           body: |
-#             See NEWS.md for release notes.
-#           draft: false
-#           prerelease: false
-
-#       - uses: r-lib/actions/setup-r@v1
-#         if: ${{ env.new_version != '' }}
-
-#       - name: Install drat
-#         if: ${{ env.new_version != '' }}
-#         run: |
-#           install.packages('drat')
-#         shell: Rscript {0}
-
-#       - name: Remove any tarballs that already exists
-#         if: ${{ env.new_version != '' }}
-#         run: |
-#           rm -f *.tar.gz
-#       - name: Download package tarball
-#         if: ${{ env.new_version != '' }}
-#         uses: actions/download-artifact@v2
-#         with:
-#           name: package_tarball
-
-#       - name: Push to drat
-#         if: ${{ env.new_version != '' }}
-#         run: |
-#           bash deploy.sh
-#       - name: Push to BroadSea
-#         if: ${{ env.new_version != '' }}
-#         run: |
-#           curl --data "build=true" -X POST https://registry.hub.docker.com/u/ohdsi/broadsea-methodslibrary/trigger/f0b51cec-4027-4781-9383-4b38b42dd4f5/
+      - name: Check if version has increased
+        run: |
+          echo "new_version="$(perl compare_versions --tag) >> $GITHUB_ENV
+      - name: Display new version number
+        if: ${{ env.new_version != '' }}
+        run: |
+          echo "${{ env.new_version }}"
+      - name: Create release
+        if: ${{ env.new_version != '' }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ env.new_version }}
+          release_name: Release ${{ env.new_version }}
+          body: |
+            See NEWS.md for release notes.
+          draft: false
+          prerelease: false


### PR DESCRIPTION
The Release Action should automatically create a new release if the version of the package has been updated on main.

The template for the GH Action was taken from CohortMethod.  I removed the steps to push to drat & broadsea because I'm not sure whether we want/need to do that for DQD.

Also added the PR template from CohortMethod, to remind folks of the style guide, etc.