### PR TITLE
Fix reEvaluateThresholds

### DIFF
--- a/R/reEvaluateThresholds.R
+++ b/R/reEvaluateThresholds.R
@@ -45,6 +45,20 @@ reEvaluateThresholds <- function(jsonFilePath,
     as.data.frame(cr)
   })
   df <- do.call(plyr::rbind.fill, df)
+  
+  # Add required fields that might be missing due to writing to json
+  if (!("CDM_FIELD_NAME" %in% colnames(df))) {
+    df$CDM_FIELD_NAME <- NA
+  }
+  if (!("ERROR" %in% colnames(df))) {
+    df$ERROR <- NA
+  }  
+  if (!("CONCEPT_ID" %in% colnames(df))) {
+    df$CONCEPT_ID <- NA
+  }
+  if (!("UNIT_CONCEPT_ID" %in% colnames(df))) {
+    df$UNIT_CONCEPT_ID <- NA
+  }
 
   # Read in  new thresholds ----------------------------------------------
   tableChecks <- .readThresholdFile(tableCheckThresholdLoc, defaultLoc = sprintf("OMOP_CDMv%s_Table_Level.csv", cdmVersion))


### PR DESCRIPTION
Fixes issue found by unit test on `reEvaluateThresholds` (#389)
Caused by running DQD initially on only one check name, causing empty columns not being written to the result json. These had to be readded before passing the results to evaluateThresholds.