### PR TITLE
Add cohort table name parameter

### DIFF
--- a/R/executeDqChecks.R
+++ b/R/executeDqChecks.R
@@ -37,6 +37,7 @@
 #' @param cohortDefinitionId        The cohort definition id for the cohort you wish to run the DQD on. The package assumes a standard OHDSI cohort table called 'Cohort'
 #'                                  with the fields cohort_definition_id and subject_id.
 #' @param cohortDatabaseSchema      The schema where the cohort table is located.
+#' @param cohortTableName           The name of the cohort table. Defaults to `cohort`.
 #' @param tablesToExclude           (OPTIONAL) Choose which CDM tables to exclude from the execution.
 #' @param cdmVersion                The CDM version to target for the data source. Options are "5.2", "5.3", or "5.4". By default, "5.3" is used.
 #' @param tableCheckThresholdLoc    The location of the threshold file for evaluating the table checks. If not specified the default thresholds will be applied.
@@ -72,6 +73,7 @@ executeDqChecks <- function(connectionDetails,
                             checkNames = c(),
                             cohortDefinitionId = c(),
                             cohortDatabaseSchema = resultsDatabaseSchema,
+                            cohortTableName = "cohort",
                             tablesToExclude = c("CONCEPT", "VOCABULARY", "CONCEPT_ANCESTOR", "CONCEPT_RELATIONSHIP", "CONCEPT_CLASS", "CONCEPT_SYNONYM", "RELATIONSHIP", "DOMAIN"),
                             cdmVersion = "5.3",
                             tableCheckThresholdLoc = "default",
@@ -89,6 +91,7 @@ executeDqChecks <- function(connectionDetails,
   stopifnot(is.character(cdmDatabaseSchema), is.character(resultsDatabaseSchema), is.numeric(numThreads))
   stopifnot(is.character(cdmSourceName), is.logical(sqlOnly), is.character(outputFolder), is.logical(verboseMode))
   stopifnot(is.logical(writeToTable), is.character(checkLevels))
+  stopifnot(is.character(cohortDatabaseSchema), is.character(cohortTableName))
 
   if (!all(checkLevels %in% c("TABLE", "FIELD", "CONCEPT"))) {
     stop('checkLevels argument must be a subset of c("TABLE", "FIELD", "CONCEPT").
@@ -246,6 +249,7 @@ executeDqChecks <- function(connectionDetails,
     cdmDatabaseSchema,
     vocabDatabaseSchema,
     cohortDatabaseSchema,
+    cohortTableName,
     cohortDefinitionId,
     outputFolder,
     sqlOnly,

--- a/R/executeDqChecks.R
+++ b/R/executeDqChecks.R
@@ -34,7 +34,7 @@
 #' @param csvFile                   (OPTIONAL) CSV file to write results
 #' @param checkLevels               Choose which DQ check levels to execute. Default is all 3 (TABLE, FIELD, CONCEPT)
 #' @param checkNames                (OPTIONAL) Choose which check names to execute. Names can be found in inst/csv/OMOP_CDM_v[cdmVersion]_Check_Descriptions.csv. Note that "cdmTable", "cdmField" and "measureValueCompleteness" are always executed.
-#' @param cohortDefinitionId        The cohort definition id for the cohort you wish to run the DQD on. The package assumes a standard OHDSI cohort table called 'Cohort'
+#' @param cohortDefinitionId        The cohort definition id for the cohort you wish to run the DQD on. The package assumes a standard OHDSI cohort table
 #'                                  with the fields cohort_definition_id and subject_id.
 #' @param cohortDatabaseSchema      The schema where the cohort table is located.
 #' @param cohortTableName           The name of the cohort table. Defaults to `cohort`.

--- a/R/runCheck.R
+++ b/R/runCheck.R
@@ -25,6 +25,7 @@
 #' @param cdmDatabaseSchema         The fully qualified database name of the CDM schema
 #' @param vocabDatabaseSchema       The fully qualified database name of the vocabulary schema (default is to set it as the cdmDatabaseSchema)
 #' @param cohortDatabaseSchema      The schema where the cohort table is located.
+#' @param cohortTableName           The name of the cohort table.
 #' @param cohortDefinitionId        The cohort definition id for the cohort you wish to run the DQD on. The package assumes a standard OHDSI cohort table called 'Cohort'
 #' @param outputFolder              The folder to output logs and SQL files to
 #' @param sqlOnly                   Should the SQLs be executed (FALSE) or just returned (TRUE)?
@@ -42,6 +43,7 @@
                       cdmDatabaseSchema,
                       vocabDatabaseSchema,
                       cohortDatabaseSchema,
+                      cohortTableName,
                       cohortDefinitionId,
                       outputFolder,
                       sqlOnly) {
@@ -77,6 +79,7 @@
         list(warnOnMissingParameters = FALSE),
         list(cdmDatabaseSchema = cdmDatabaseSchema),
         list(cohortDatabaseSchema = cohortDatabaseSchema),
+        list(cohortTableName = cohortTableName),
         list(cohortDefinitionId = cohortDefinitionId),
         list(vocabDatabaseSchema = vocabDatabaseSchema),
         list(cohort = cohort),

--- a/inst/sql/sql_server/concept_plausible_gender.sql
+++ b/inst/sql/sql_server/concept_plausible_gender.sql
@@ -12,6 +12,7 @@ plausibleGender = @plausibleGender
 {@cohort}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -35,7 +36,7 @@ FROM
 			INNER JOIN @cdmDatabaseSchema.person p
 			ON cdmTable.person_id = p.person_id
 			{@cohort}?{
-      	JOIN @cohortDatabaseSchema.cohort c
+      	JOIN @cohortDatabaseSchema.@cohortTableName c
       	  ON cdmTable.person_id = c.subject_id
       	  AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -49,7 +50,7 @@ FROM
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
   	{@cohort}?{
-    	JOIN @cohortDatabaseSchema.cohort c
+    	JOIN @cohortDatabaseSchema.@cohortTableName c
       	ON cdmTable.person_id = c.subject_id
       	AND c.cohort_definition_id = @cohortDefinitionId
   	}

--- a/inst/sql/sql_server/concept_plausible_unit_concept_ids.sql
+++ b/inst/sql/sql_server/concept_plausible_unit_concept_ids.sql
@@ -11,6 +11,7 @@ plausibleUnitConceptIds = @plausibleUnitConceptIds
 {@cohort}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -33,7 +34,7 @@ FROM
 		  m.* 
 		FROM @cdmDatabaseSchema.@cdmTableName m
   		{@cohort}?{
-        JOIN @cohortDatabaseSchema.COHORT c
+        JOIN @cohortDatabaseSchema.@cohortTableName c
     		ON m.person_id = c.subject_id
     		AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -53,7 +54,7 @@ FROM
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName m
   	{@cohort}?{
-    	JOIN @cohortDatabaseSchema.cohort c
+    	JOIN @cohortDatabaseSchema.@cohortTableName c
     	ON m.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
   	}

--- a/inst/sql/sql_server/concept_plausible_value_high.sql
+++ b/inst/sql/sql_server/concept_plausible_value_high.sql
@@ -13,6 +13,7 @@ plausibleValueHigh = @plausibleValueHigh
 {@cohort}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -35,7 +36,7 @@ FROM
 		  m.* 
 		FROM @cdmDatabaseSchema.@cdmTableName m
   		{@cohort}?{
-      	JOIN @cohortDatabaseSchema.cohort c
+      	JOIN @cohortDatabaseSchema.@cohortTableName c
       	ON m.person_id = c.subject_id
       	AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -51,7 +52,7 @@ FROM
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName m
   	{@cohort}?{
-    	JOIN @cohortDatabaseSchema.cohort c
+    	JOIN @cohortDatabaseSchema.@cohortTableName c
     	ON m.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
   	}

--- a/inst/sql/sql_server/concept_plausible_value_low.sql
+++ b/inst/sql/sql_server/concept_plausible_value_low.sql
@@ -12,6 +12,7 @@ plausibleValueLow = @plausibleValueLow
 {@cohort}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -33,7 +34,7 @@ FROM (
 		  m.* 
 		FROM @cdmDatabaseSchema.@cdmTableName m
   		{@cohort}?{
-      	JOIN @cohortDatabaseSchema.cohort c
+      	JOIN @cohortDatabaseSchema.@cohortTableName c
       	ON m.person_id = c.subject_id
       	AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -49,7 +50,7 @@ FROM (
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName m
   	{@cohort}?{
-    	JOIN @cohortDatabaseSchema.cohort c
+    	JOIN @cohortDatabaseSchema.@cohortTableName c
     	ON m.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
   	}

--- a/inst/sql/sql_server/field_concept_record_completeness.sql
+++ b/inst/sql/sql_server/field_concept_record_completeness.sql
@@ -9,6 +9,7 @@ cdmFieldName = @cdmFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -29,7 +30,7 @@ FROM (
 		  cdmTable.* 
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
   		{@cohort & '@runForCohort' == 'Yes'}?{
-      	JOIN @cohortDatabaseSchema.cohort c
+      	JOIN @cohortDatabaseSchema.@cohortTableName c
       	ON cdmTable.person_id = c.subject_id
       	AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -41,7 +42,7 @@ FROM (
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	  {@cohort & '@runForCohort' == 'Yes'}?{
-    	JOIN @cohortDatabaseSchema.cohort c
+    	JOIN @cohortDatabaseSchema.@cohortTableName c
     	ON cdmTable.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
   	}

--- a/inst/sql/sql_server/field_fk_class.sql
+++ b/inst/sql/sql_server/field_fk_class.sql
@@ -12,6 +12,7 @@ fkClass = @fkClass
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -35,7 +36,7 @@ FROM (
 		  LEFT JOIN @vocabDatabaseSchema.concept co
 		  ON cdmTable.@cdmFieldName = co.concept_id
 		  {@cohort & '@runForCohort' == 'Yes'}?{
-      	JOIN @cohortDatabaseSchema.cohort c 
+      	JOIN @cohortDatabaseSchema.@cohortTableName c 
       	ON cdmTable.person_id = c.subject_id
       	AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -49,7 +50,7 @@ FROM (
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	  {@cohort & '@runForCohort' == 'Yes'}?{
-    	JOIN @cohortDatabaseSchema.cohort c 
+    	JOIN @cohortDatabaseSchema.@cohortTableName c 
     	ON cdmTable.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/field_fk_domain.sql
+++ b/inst/sql/sql_server/field_fk_domain.sql
@@ -13,6 +13,7 @@ fkDomain = @fkDomain
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -35,7 +36,7 @@ FROM (
 		  LEFT JOIN @vocabDatabaseSchema.concept co
 		  ON cdmTable.@cdmFieldName = co.concept_id
 		  {@cohort & '@runForCohort' == 'Yes'}?{
-      	JOIN @cohortDatabaseSchema.cohort c 
+      	JOIN @cohortDatabaseSchema.@cohortTableName c 
       	ON cdmTable.person_id = c.subject_id
       	AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -49,7 +50,7 @@ FROM (
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	{@cohort & '@runForCohort' == 'Yes'}?{
-    JOIN @cohortDatabaseSchema.COHORT c 
+    JOIN @cohortDatabaseSchema.@cohortTableName c 
     ON cdmTable.PERSON_ID = c.SUBJECT_ID
     AND c.COHORT_DEFINITION_ID = @cohortDefinitionId
   }

--- a/inst/sql/sql_server/field_is_not_nullable.sql
+++ b/inst/sql/sql_server/field_is_not_nullable.sql
@@ -11,6 +11,7 @@ cdmFieldName = @cdmFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -32,7 +33,7 @@ FROM (
 		  cdmTable.* 
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		  {@cohort & '@runForCohort' == 'Yes'}?{
-      	JOIN @cohortDatabaseSchema.cohort c
+      	JOIN @cohortDatabaseSchema.@cohortTableName c
       	ON cdmTable.person_id = c.subject_id
       	AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -45,7 +46,7 @@ FROM (
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	  {@cohort & '@runForCohort' == 'Yes'}?{
-    	JOIN @cohortDatabaseSchema.cohort c 
+    	JOIN @cohortDatabaseSchema.@cohortTableName c 
     	ON cdmTable.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/field_is_primary_key.sql
+++ b/inst/sql/sql_server/field_is_primary_key.sql
@@ -11,6 +11,7 @@ cdmFieldName = @cdmFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -34,7 +35,7 @@ FROM
 			cdmTable.* 
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 			{@cohort & '@runForCohort' == 'Yes'}?{
-  			JOIN @cohortDatabaseSchema.cohort c 
+  			JOIN @cohortDatabaseSchema.@cohortTableName c 
   			ON cdmTable.person_id = c.subject_id
   			AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -53,7 +54,7 @@ FROM
 		COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		{@cohort & '@runForCohort' == 'Yes'}?{
-			JOIN @cohortDatabaseSchema.cohort c 
+			JOIN @cohortDatabaseSchema.@cohortTableName c 
 			ON cdmTable.person_id = c.subject_id
 			AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/field_is_standard_valid_concept.sql
+++ b/inst/sql/sql_server/field_is_standard_valid_concept.sql
@@ -12,6 +12,7 @@ cdmFieldName = @cdmFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -34,7 +35,7 @@ FROM
 			cdmTable.* 
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 			{@cohort & '@runForCohort' == 'Yes'}?{
-  			JOIN @cohortDatabaseSchema.cohort c 
+  			JOIN @cohortDatabaseSchema.@cohortTableName c 
   			ON cdmTable.person_id = c.subject_id
   			AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -50,7 +51,7 @@ FROM
 		COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		{@cohort & '@runForCohort' == 'Yes'}?{
-  		JOIN @cohortDatabaseSchema.cohort c 
+  		JOIN @cohortDatabaseSchema.@cohortTableName c 
   		ON cdmTable.person_id = c.subject_id
   		AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/field_measure_value_completeness.sql
+++ b/inst/sql/sql_server/field_measure_value_completeness.sql
@@ -10,6 +10,7 @@ cdmFieldName = @cdmFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -33,7 +34,7 @@ FROM
 			cdmTable.* 
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 			{@cohort & '@runForCohort' == 'Yes'}?{
-  			JOIN @cohortDatabaseSchema.cohort c 
+  			JOIN @cohortDatabaseSchema.@cohortTableName c 
   			ON cdmTable.person_id = c.subject_id
   			AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -46,7 +47,7 @@ FROM
 		COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	  {@cohort & '@runForCohort' == 'Yes'}?{
-    	JOIN @cohortDatabaseSchema.cohort c 
+    	JOIN @cohortDatabaseSchema.@cohortTableName c 
     	ON cdmTable.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/field_plausible_during_life.sql
+++ b/inst/sql/sql_server/field_plausible_during_life.sql
@@ -10,6 +10,7 @@ cdmFieldName = @cdmFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -33,7 +34,7 @@ FROM
 			cdmTable.*
     	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
     		{@cohort & '@runForCohort' == 'Yes'}?{
-    			JOIN @cohortDatabaseSchema.cohort c ON cdmTable.person_id = c.subject_id
+    			JOIN @cohortDatabaseSchema.@cohortTableName c ON cdmTable.person_id = c.subject_id
     				AND c.COHORT_DEFINITION_ID = @cohortDefinitionId
     		}
     	JOIN @cdmDatabaseSchema.death de ON cdmTable.person_id = de.person_id
@@ -46,7 +47,7 @@ FROM
 		COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		{@cohort & '@runForCohort' == 'Yes'}?{
-    		JOIN @cohortDatabaseSchema.cohort c ON cdmTable.person_id = c.subject_id
+    		JOIN @cohortDatabaseSchema.@cohortTableName c ON cdmTable.person_id = c.subject_id
     			AND c.cohort_definition_id = @cohortDefinitionId
     	}
 	WHERE person_id IN

--- a/inst/sql/sql_server/field_plausible_temporal_after.sql
+++ b/inst/sql/sql_server/field_plausible_temporal_after.sql
@@ -12,6 +12,7 @@ plausibleTemporalAfterFieldName = @plausibleTemporalAfterFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -36,7 +37,7 @@ FROM
     		{@cdmDatabaseSchema.@cdmTableName != @cdmDatabaseSchema.@plausibleTemporalAfterTableName}?{
 				JOIN @cdmDatabaseSchema.@plausibleTemporalAfterTableName plausibleTable ON cdmTable.person_id = plausibleTable.person_id}
 			{@cohort & '@runForCohort' == 'Yes'}?{
-    			JOIN @cohortDatabaseSchema.cohort c ON cdmTable.person_id = c.subject_id
+    			JOIN @cohortDatabaseSchema.@cohortTableName c ON cdmTable.person_id = c.subject_id
     				AND c.cohort_definition_id = @cohortDefinitionId
 			}
     WHERE 
@@ -56,7 +57,7 @@ FROM
 		COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		{@cohort & '@runForCohort' == 'Yes'}?{
-  			JOIN @cohortDatabaseSchema.cohort c ON cdmTable.person_id = c.subject_id
+  			JOIN @cohortDatabaseSchema.@cohortTableName c ON cdmTable.person_id = c.subject_id
     			AND c.cohort_definition_id = @cohortDefinitionId 
 		}
 ) denominator

--- a/inst/sql/sql_server/field_plausible_value_high.sql
+++ b/inst/sql/sql_server/field_plausible_value_high.sql
@@ -11,6 +11,7 @@ plausibleValueHigh = @plausibleValueHigh
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -32,7 +33,7 @@ FROM
 		cdmTable.*
     	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
     		{@cohort & '@runForCohort' == 'Yes'}?{
-    			JOIN @cohortDatabaseSchema.cohort c ON cdmTable.person_id = c.subject_id
+    			JOIN @cohortDatabaseSchema.@cohortTableName c ON cdmTable.person_id = c.subject_id
     				AND c.cohort_definition_id = @cohortDefinitionId
     		}
     		{@cdmDatatype == "datetime" | @cdmDatatype == "date"}?{
@@ -48,7 +49,7 @@ FROM
 		COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		{@cohort & '@runForCohort' == 'Yes'}?{
-    		JOIN @cohortDatabaseSchema.cohort c ON cdmTable.person_id = c.subject_id
+    		JOIN @cohortDatabaseSchema.@cohortTableName c ON cdmTable.person_id = c.subject_id
     			AND c.cohort_definition_id = @cohortDefinitionId
     	}
   	WHERE @cdmFieldName IS NOT NULL

--- a/inst/sql/sql_server/field_plausible_value_low.sql
+++ b/inst/sql/sql_server/field_plausible_value_low.sql
@@ -11,6 +11,7 @@ plausibleValueLow = @plausibleValueLow
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -30,7 +31,7 @@ FROM (
 		  cdmTable.*
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
   		{@cohort & '@runForCohort' == 'Yes'}?{
-        JOIN @cohortDatabaseSchema.cohort c
+        JOIN @cohortDatabaseSchema.@cohortTableName c
         ON cdmTable.person_id = c.subject_id
         AND c.cohort_definition_id = @cohortDefinitionId
       }
@@ -47,7 +48,7 @@ FROM (
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	  {@cohort & '@runForCohort' == 'Yes'}?{
-      JOIN @cohortDatabaseSchema.cohort c
+      JOIN @cohortDatabaseSchema.@cohortTableName c
       ON cdmTable.person_id = c.subject_id
       AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/field_source_value_completeness.sql
+++ b/inst/sql/sql_server/field_source_value_completeness.sql
@@ -10,6 +10,7 @@ standardConceptFieldName = @standardConceptFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -29,7 +30,7 @@ FROM (
 		  cdmTable.@cdmFieldName
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		  {@cohort & '@runForCohort' == 'Yes'}?{
-        JOIN @cohortDatabaseSchema.cohort c
+        JOIN @cohortDatabaseSchema.@cohortTableName c
         ON cdmTable.PERSON_ID = c.subject_id
         AND c.cohort_definition_id = @cohortDefinitionId
       }
@@ -42,7 +43,7 @@ FROM (
 	  COUNT_BIG(distinct cdmTable.@cdmFieldName) + COUNT(DISTINCT CASE WHEN cdmTable.@cdmFieldName IS NULL THEN 1 END) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
   	{@cohort & '@runForCohort' == 'Yes'}?{
-      JOIN @cohortDatabaseSchema.cohort c
+      JOIN @cohortDatabaseSchema.@cohortTableName c
       ON cdmTable.person_id = c.subject_id
       AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/field_within_visit_dates.sql
+++ b/inst/sql/sql_server/field_within_visit_dates.sql
@@ -9,6 +9,7 @@ cdmFieldName = @cdmFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -29,7 +30,7 @@ FROM (
 		  cdmTable.*
     FROM @cdmDatabaseSchema.@cdmTableName cdmTable
       {@cohort & '@runForCohort' == 'Yes'}?{
-        JOIN @cohortDatabaseSchema.cohort c
+        JOIN @cohortDatabaseSchema.@cohortTableName c
         ON cdmTable.person_id = c.subject_id
         AND c.cohort_definition_id = @cohortDefinitionId
       }
@@ -45,7 +46,7 @@ FROM (
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	  {@cohort & '@runForCohort' == 'Yes'}?{
-      JOIN @cohortDatabaseSchema.cohort c
+      JOIN @cohortDatabaseSchema.@cohortTableName c
       ON cdmTable.person_id = c.subject_id
       AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/is_foreign_key.sql
+++ b/inst/sql/sql_server/is_foreign_key.sql
@@ -13,6 +13,7 @@ fkFieldName = @fkFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -33,7 +34,7 @@ FROM (
 		  cdmTable.*
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		  {@cohort & '@runForCohort' == 'Yes'}?{
-  	    JOIN @cohortDatabaseSchema.cohort c
+  	    JOIN @cohortDatabaseSchema.@cohortTableName c
   	    ON cdmTable.person_id = c.subject_id
   	    AND c.cohort_definition_id = @cohortDefinitionId
       }
@@ -49,7 +50,7 @@ FROM (
 	  COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	  {@cohort & '@runForCohort' == 'Yes'}?{
-      JOIN @cohortDatabaseSchema.cohort c
+      JOIN @cohortDatabaseSchema.@cohortTableName c
       ON cdmTable.person_id = c.subject_id
       AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/table_concept_completeness.sql
+++ b/inst/sql/sql_server/table_concept_completeness.sql
@@ -12,6 +12,7 @@ cdmSourceFieldName = @cdmSourceFieldName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 
 **********/
@@ -35,7 +36,7 @@ FROM
 			cdmTable.* 
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 			{@cohort & '@runForCohort' == 'Yes'}?{
-    		JOIN @cohortDatabaseSchema.cohort c 
+    		JOIN @cohortDatabaseSchema.@cohortTableName c 
     		ON cdmTable.person_id = c.subject_id
     		AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -48,7 +49,7 @@ FROM
 	SELECT COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 	{@cohort & '@runForCohort' == 'Yes'}?{
-    JOIN @cohortDatabaseSchema.cohort c 
+    JOIN @cohortDatabaseSchema.@cohortTableName c 
     ON cdmTable.person_id = c.subject_id
     AND c.cohort_definition_id = @cohortDefinitionId
   }

--- a/inst/sql/sql_server/table_condition_era_completeness.sql
+++ b/inst/sql/sql_server/table_condition_era_completeness.sql
@@ -9,6 +9,7 @@ cdmTableName = @cdmTableName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -30,7 +31,7 @@ FROM
 		co.person_id
 		FROM @cdmDatabaseSchema.condition_occurrence co
 			{@cohort & '@runForCohort' == 'Yes'}?{
-    		JOIN @cohortDatabaseSchema.cohort c 
+    		JOIN @cohortDatabaseSchema.@cohortTableName c 
     		ON co.person_id = c.subject_id
     		AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -44,7 +45,7 @@ FROM
 		COUNT_BIG(DISTINCT person_id) AS num_rows
 	FROM @cdmDatabaseSchema.condition_occurrence co
 		{@cohort & '@runForCohort' == 'Yes'}?{
-    	JOIN @cohortDatabaseSchema.cohort c 
+    	JOIN @cohortDatabaseSchema.@cohortTableName c 
     	ON co.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/inst/sql/sql_server/table_person_completeness.sql
+++ b/inst/sql/sql_server/table_person_completeness.sql
@@ -10,6 +10,7 @@ cdmTableName = @cdmTableName
 {@cohort & '@runForCohort' == 'Yes'}?{
 cohortDefinitionId = @cohortDefinitionId
 cohortDatabaseSchema = @cohortDatabaseSchema
+cohortTableName = @cohortTableName
 }
 **********/
 
@@ -32,7 +33,7 @@ FROM
 			cdmTable.* 
 		FROM @cdmDatabaseSchema.person cdmTable
 		  {@cohort & '@runForCohort' == 'Yes'}?{
-    		JOIN @cohortDatabaseSchema.cohort c 
+    		JOIN @cohortDatabaseSchema.@cohortTableName c 
     		ON cdmTable.person_id = c.subject_id
     		AND c.cohort_definition_id = @cohortDefinitionId
     	}
@@ -47,7 +48,7 @@ FROM
 		COUNT_BIG(*) AS num_rows
 	FROM @cdmDatabaseSchema.person cdmTable
 		{@cohort & '@runForCohort' == 'Yes'}?{
-    	JOIN @cohortDatabaseSchema.cohort c 
+    	JOIN @cohortDatabaseSchema.@cohortTableName c 
     	ON cdmTable.person_id = c.subject_id
     	AND c.cohort_definition_id = @cohortDefinitionId
     }

--- a/man/dot-runCheck.Rd
+++ b/man/dot-runCheck.Rd
@@ -14,6 +14,7 @@
   cdmDatabaseSchema,
   vocabDatabaseSchema,
   cohortDatabaseSchema,
+  cohortTableName,
   cohortDefinitionId,
   outputFolder,
   sqlOnly
@@ -35,6 +36,8 @@
 \item{vocabDatabaseSchema}{The fully qualified database name of the vocabulary schema (default is to set it as the cdmDatabaseSchema)}
 
 \item{cohortDatabaseSchema}{The schema where the cohort table is located.}
+
+\item{cohortTableName}{The name of the cohort table.}
 
 \item{cohortDefinitionId}{The cohort definition id for the cohort you wish to run the DQD on. The package assumes a standard OHDSI cohort table called 'Cohort'}
 

--- a/man/executeDqChecks.Rd
+++ b/man/executeDqChecks.Rd
@@ -65,7 +65,7 @@ executeDqChecks(
 
 \item{checkNames}{(OPTIONAL) Choose which check names to execute. Names can be found in inst/csv/OMOP_CDM_v[cdmVersion]_Check_Descriptions.csv. Note that "cdmTable", "cdmField" and "measureValueCompleteness" are always executed.}
 
-\item{cohortDefinitionId}{The cohort definition id for the cohort you wish to run the DQD on. The package assumes a standard OHDSI cohort table called 'Cohort'
+\item{cohortDefinitionId}{The cohort definition id for the cohort you wish to run the DQD on. The package assumes a standard OHDSI cohort table
 with the fields cohort_definition_id and subject_id.}
 
 \item{cohortDatabaseSchema}{The schema where the cohort table is located.}

--- a/man/executeDqChecks.Rd
+++ b/man/executeDqChecks.Rd
@@ -23,6 +23,7 @@ executeDqChecks(
   checkNames = c(),
   cohortDefinitionId = c(),
   cohortDatabaseSchema = resultsDatabaseSchema,
+  cohortTableName = "cohort",
   tablesToExclude = c("CONCEPT", "VOCABULARY", "CONCEPT_ANCESTOR",
     "CONCEPT_RELATIONSHIP", "CONCEPT_CLASS", "CONCEPT_SYNONYM", "RELATIONSHIP", "DOMAIN"),
   cdmVersion = "5.3",
@@ -68,6 +69,8 @@ executeDqChecks(
 with the fields cohort_definition_id and subject_id.}
 
 \item{cohortDatabaseSchema}{The schema where the cohort table is located.}
+
+\item{cohortTableName}{The name of the cohort table. Defaults to `cohort`.}
 
 \item{tablesToExclude}{(OPTIONAL) Choose which CDM tables to exclude from the execution.}
 

--- a/tests/testthat/test-execute.R
+++ b/tests/testthat/test-execute.R
@@ -86,7 +86,7 @@ test_that("Execute a single DQ check on remote databases", {
   on.exit(unlink(outputFolder, recursive = TRUE))
 
   dbTypes <- c(
-    # "oracle",
+    "oracle",
     "postgresql",
     "sql server"
   )
@@ -95,7 +95,6 @@ test_that("Execute a single DQ check on remote databases", {
     sysUser <- Sys.getenv(sprintf("CDM5_%s_USER", toupper(gsub(" ", "_", dbType))))
     sysPassword <- URLdecode(Sys.getenv(sprintf("CDM5_%s_PASSWORD", toupper(gsub(" ", "_", dbType)))))
     sysServer <- Sys.getenv(sprintf("CDM5_%s_SERVER", toupper(gsub(" ", "_", dbType))))
-    sysExtraSettings <- Sys.getenv(sprintf("CDM5_%s_EXTRA_SETTINGS", toupper(gsub(" ", "_", dbType))))
     if (sysUser != "" &
       sysPassword != "" &
       sysServer != "") {
@@ -107,7 +106,6 @@ test_that("Execute a single DQ check on remote databases", {
         user = sysUser,
         password = sysPassword,
         server = sysServer,
-        extraSettings = sysExtraSettings,
         pathToDriver = jdbcDriverFolder
       )
 

--- a/tests/testthat/test-execute.R
+++ b/tests/testthat/test-execute.R
@@ -80,6 +80,43 @@ test_that("Execute CONCEPT checks on Synthea/Eunomia", {
   expect_true(nrow(results$CheckResults) > 0)
 })
 
+test_that("Execute a single DQ check on a cohort in Synthea/Eunomia", {
+  # simulating cohort table entries using observation period data
+  connection <- DatabaseConnector::connect(connectionDetailsEunomia)
+  on.exit(DatabaseConnector::disconnect(connection), add = TRUE)
+  fakeCohortId <- 123
+  DatabaseConnector::renderTranslateExecuteSql(connection, 
+                                               "INSERT INTO @results_schema.cohort SELECT @cohort_id, person_id, observation_period_start_date, observation_period_end_date FROM @cdm_schema.observation_period LIMIT 10;", 
+                                               results_schema = resultsDatabaseSchema,
+                                               cohort_id = fakeCohortId,
+                                               cdm_schema = cdmDatabaseSchema
+                                               )
+  
+  outputFolder <- tempfile("dqd_")
+  on.exit(unlink(outputFolder, recursive = TRUE))
+  
+  expect_warning(
+    results <- executeDqChecks(
+      connectionDetails = connectionDetailsEunomia,
+      cdmDatabaseSchema = cdmDatabaseSchema,
+      resultsDatabaseSchema = resultsDatabaseSchema,
+      cdmSourceName = "Eunomia",
+      checkNames = "measurePersonCompleteness",
+      outputFolder = outputFolder,
+      writeToTable = F,
+      cohortTableName = "cohort",
+      cohortDefinitionId = fakeCohortId
+    ),
+    regexp = "^Missing check names.*"
+  )
+  
+  expect_true(nrow(results$CheckResults) > 1)
+  DatabaseConnector::renderTranslateExecuteSql(connection, 
+                                               "DELETE FROM @results_schema.cohort WHERE cohort_definition_id = @cohort_id", 
+                                               results_schema = resultsDatabaseSchema,
+                                               cohort_id = fakeCohortId)
+})
+
 
 test_that("Execute a single DQ check on remote databases", {
   outputFolder <- tempfile("dqd_")
@@ -189,7 +226,7 @@ test_that("Write JSON results", {
 test_that("Execute DQ checks and write to table", {
   outputFolder <- tempfile("dqd_")
   on.exit(unlink(outputFolder, recursive = TRUE))
-  
+
   expect_warning(
     results <- executeDqChecks(
       connectionDetails = connectionDetailsEunomia,


### PR DESCRIPTION
This PR adds a new parameter to `executeDqChecks` and `runCheck` - `cohortTableName`.  This allows users to specify the name of the cohort table they'd like to use if they're running DQD on a cohort.

This feature was requested in #400 and we think it'll benefit other users as well, because in the `CohortGenerator` package users have the option to specify their own cohort table name.

Additionally, I've included a change in the test file to re-include the remote oracle database in our tests.  The inclusion of the unused `extraSettings` parameter in connecting to this database was causing issues, so I removed it and now tests run fine again on oracle.