### PR TITLE
Add parentheses to fix OR logic in cdmDatatype check

### DIFF
--- a/inst/sql/sql_server/field_cdm_datatype.sql
+++ b/inst/sql/sql_server/field_cdm_datatype.sql
@@ -30,11 +30,9 @@ FROM
 		  cdmTable.* 
 		FROM @cdmDatabaseSchema.@cdmTableName cdmTable
 		WHERE 
-		  ISNUMERIC(cdmTable.@cdmFieldName) = 0 
-		  OR (
-		    ISNUMERIC(cdmTable.@cdmFieldName) = 1 
-		    AND CHARINDEX('.', CAST(ABS(cdmTable.@cdmFieldName) AS varchar)) != 0
-		  )
+		  (ISNUMERIC(cdmTable.@cdmFieldName) = 0 
+		    OR (ISNUMERIC(cdmTable.@cdmFieldName) = 1 
+		      AND CHARINDEX('.', CAST(ABS(cdmTable.@cdmFieldName) AS varchar)) != 0))
       AND cdmTable.@cdmFieldName IS NOT NULL
 		/*violatedRowsEnd*/
 	) violated_rows


### PR DESCRIPTION
Fixes #425 .  Adds parentheses around the "OR" clause checking if a value is an integer.  This way the non-NULL clause is applied to all rows.