### PR TITLE
Fix issue #451 - properly read plausibleUnitConceptIds

### DIFF
--- a/R/listChecks.R
+++ b/R/listChecks.R
@@ -34,66 +34,23 @@ listDqChecks <- function(cdmVersion = "5.3", tableCheckThresholdLoc = "default",
       "csv",
       sprintf("OMOP_CDMv%s_Check_Descriptions.csv", cdmVersion),
       package = "DataQualityDashboard"
-    ))
-  dqChecks$checkDescriptions <- as.data.frame(dqChecks$checkDescriptions)
-
-
-  if (tableCheckThresholdLoc == "default") {
-    dqChecks$tableChecks <-
-      read_csv(
-        system.file(
-          "csv",
-          sprintf("OMOP_CDMv%s_Table_Level.csv", cdmVersion),
-          package = "DataQualityDashboard"
-        ),
-        na = c(" ", "")
       )
-    dqChecks$tableChecks <- as.data.frame(dqChecks$tableChecks)
-  } else {
-    dqChecks$tableChecks <- read_csv(
-      tableCheckThresholdLoc,
-      na = c(" ", "")
     )
-    dqChecks$tableChecks <- as.data.frame(dqChecks$tableChecks)
-  }
 
-  if (fieldCheckThresholdLoc == "default") {
-    dqChecks$fieldChecks <-
-      read_csv(
-        system.file(
-          "csv",
-          sprintf("OMOP_CDMv%s_Field_Level.csv", cdmVersion),
-          package = "DataQualityDashboard"
-        ),
-        na = c(" ", "")
-      )
-    dqChecks$fieldChecks <- as.data.frame(dqChecks$fieldChecks)
-  } else {
-    dqChecks$fieldChecks <- read_csv(
-      fieldCheckThresholdLoc,
-      na = c(" ", "")
-    )
-    dqChecks$fieldChecks <- as.data.frame(dqChecks$fieldChecks)
-  }
+  dqChecks$tableChecks <- .readThresholdFile(
+    checkThresholdLoc = tableCheckThresholdLoc,
+    defaultLoc = sprintf("OMOP_CDMv%s_Table_Level.csv", cdmVersion)
+  )
 
-  if (conceptCheckThresholdLoc == "default") {
-    dqChecks$conceptChecks <-
-      read_csv(
-        system.file(
-          "csv",
-          sprintf("OMOP_CDMv%s_Concept_Level.csv", cdmVersion),
-          package = "DataQualityDashboard"
-        ),
-        na = c(" ", "")
-      )
-    dqChecks$conceptChecks <- as.data.frame(dqChecks$conceptChecks)
-  } else {
-    dqChecks$conceptChecks <- read_csv(
-      conceptCheckThresholdLoc,
-      na = c(" ", "")
-    )
-    dqChecks$conceptChecks <- as.data.frame(dqChecks$conceptChecks)
-  }
+  dqChecks$fieldChecks <- .readThresholdFile(
+    checkThresholdLoc = fieldCheckThresholdLoc,
+    defaultLoc = sprintf("OMOP_CDMv%s_Field_Level.csv", cdmVersion)
+  )
+
+  dqChecks$conceptChecks <- .readThresholdFile(
+    checkThresholdLoc = conceptCheckThresholdLoc,
+    defaultLoc = sprintf("OMOP_CDMv%s_Concept_Level.csv", cdmVersion)
+  )
 
   return(dqChecks)
 }


### PR DESCRIPTION
Fix issue #451 

.readThresholdFile() is used everywhere else.  This makes listChecks.R consistent with that approach.

This is also related to issue #436 and pull request #444 