### PR TITLE
Fix descendant concept bug in sqlonly

### DIFF
--- a/R/sqlOnly.R
+++ b/R/sqlOnly.R
@@ -231,7 +231,19 @@
         cdmFieldName
       )
     } else if (checkLevel == "CONCEPT") {
-      if (is.na(unitConceptId)) {
+      if (is.na(unitConceptId) &&
+          grepl(",", conceptId)) {
+        thresholdFilter <- sprintf(
+          "conceptChecks$%s[conceptChecks$cdmTableName == '%s' &
+                                  conceptChecks$cdmFieldName == '%s' &
+                                  conceptChecks$conceptId == '%s']",
+          thresholdField,
+          cdmTableName,
+          cdmFieldName,
+          conceptId
+        )
+      } else if (is.na(unitConceptId) &&
+                 !grepl(",", conceptId)) {
         thresholdFilter <- sprintf(
           "conceptChecks$%s[conceptChecks$cdmTableName == '%s' &
                                   conceptChecks$cdmFieldName == '%s' &


### PR DESCRIPTION
A change was made [here](https://github.com/OHDSI/DataQualityDashboard/pull/524/files#diff-654ee34f6f8ea2a10a8aee52db3d0ab6b8b6b16140ba9c2b03666b23c631e75f) to accommodate multiple concepts input to the new plausibleGenderUseDescendants check.  We forgot to make that same change in the SqlOnly code.

This PR fixes #545 