### PR TITLE
Show severity in Shiny app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DataQualityDashboard
 Type: Package
 Title: Execute and View Data Quality Checks on OMOP CDM Database
-Version: 2.8.6
+Version: 2.8.6.900
 Date: 2026-01-22
 Authors@R: c(
   person("Katy", "Sadowski", email = "sadowski@ohdsi.org", role = c("aut", "cre")),

--- a/inst/shinyApps/app.R
+++ b/inst/shinyApps/app.R
@@ -4,22 +4,26 @@ server <- function(input, output, session) {
     jsonPath <- Sys.getenv("jsonPath")
     results <- DataQualityDashboard::convertJsonResultsFileCase(jsonPath, writeToFile = FALSE, targetCase = "camel")
     
-    # Read checkDescription to get Severity status
-    cdmVersion <- results$Metadata$cdmVersion
-    checkDescriptionsDf <- readr::read_csv(
-      file = system.file(
-        "csv",
-        sprintf("OMOP_CDMv%s_Check_Descriptions.csv", substr(cdmVersion, 1, 3)),  
-        package = "DataQualityDashboard"
-      ),
-      show_col_types = FALSE
-    )
-
-    results$CheckResults <- results$CheckResults |>
-      dplyr::left_join(
-        dplyr::select(checkDescriptionsDf, checkName, severity),
-        dplyr::join_by('checkName')
+    tryCatch({
+      # Read checkDescription to get severity status for each check
+      cdmVersion <- results$Metadata$cdmVersion
+      checkDescriptionsDf <- readr::read_csv(
+        file = system.file(
+          "csv",
+          sprintf("OMOP_CDMv%s_Check_Descriptions.csv", substr(sub('$v', '', cdmVersion), 1, 3)),  
+          package = "DataQualityDashboard"
+        ),
+        show_col_types = FALSE
       )
+
+      results$CheckResults <- results$CheckResults |>
+        dplyr::left_join(
+          dplyr::select(checkDescriptionsDf, checkName, severity),
+          dplyr::join_by('checkName')
+        )
+    }, error = function(e) {
+      results$CheckResults$severity <- NA
+    })
     
     results$appVersion <- as.character(packageVersion('DataQualityDashboard'))
     
@@ -27,7 +31,7 @@ server <- function(input, output, session) {
     results <- jsonlite::parse_json(jsonlite::toJSON(results))    
 
     session$sendCustomMessage("results", results)
-  })
+    })
 }
 
 ui <- fluidPage(

--- a/inst/shinyApps/app.R
+++ b/inst/shinyApps/app.R
@@ -9,7 +9,7 @@ server <- function(input, output, session) {
     checkDescriptionsDf <- readr::read_csv(
       file = system.file(
         "csv",
-        sprintf("OMOP_CDMv%s_Check_Descriptions.csv", cdmVersion),  
+        sprintf("OMOP_CDMv%s_Check_Descriptions.csv", substr(cdmVersion, 1, 3)),  
         package = "DataQualityDashboard"
       ),
       show_col_types = FALSE
@@ -21,6 +21,11 @@ server <- function(input, output, session) {
         dplyr::join_by('checkName')
       )
     
+    results$appVersion <- as.character(packageVersion('DataQualityDashboard'))
+    
+    # Fix json formatting
+    results <- jsonlite::parse_json(jsonlite::toJSON(results))    
+
     session$sendCustomMessage("results", results)
   })
 }

--- a/inst/shinyApps/app.R
+++ b/inst/shinyApps/app.R
@@ -3,7 +3,24 @@ server <- function(input, output, session) {
   observe({
     jsonPath <- Sys.getenv("jsonPath")
     results <- DataQualityDashboard::convertJsonResultsFileCase(jsonPath, writeToFile = FALSE, targetCase = "camel")
-    results <- jsonlite::parse_json(jsonlite::toJSON(results))
+    
+    # Read checkDescription to get Severity status
+    cdmVersion <- results$Metadata$cdmVersion
+    checkDescriptionsDf <- readr::read_csv(
+      file = system.file(
+        "csv",
+        sprintf("OMOP_CDMv%s_Check_Descriptions.csv", cdmVersion),  
+        package = "DataQualityDashboard"
+      ),
+      show_col_types = FALSE
+    )
+
+    results$CheckResults <- results$CheckResults |>
+      dplyr::left_join(
+        dplyr::select(checkDescriptionsDf, checkName, severity),
+        dplyr::join_by('checkName')
+      )
+    
     session$sendCustomMessage("results", results)
   })
 }

--- a/inst/shinyApps/www/htmlwidgets/lib/dqCheckRenderer.js
+++ b/inst/shinyApps/www/htmlwidgets/lib/dqCheckRenderer.js
@@ -4,6 +4,8 @@ class DqCheckRenderer extends HTMLElement {
         {{#each checks}}
           <div><b>Check Details</b></div>        
           <div>{{this.checkName}} - {{this.checkLevel}} - {{this.CDM_TABLE}} - {{this.CDM_FIELD}}</div>
+          <div><b>Check Severity</b></div>
+          <div>{{this.severity}}</div>
           <div><b>Check Description</b></div>
           <div>{{this.checkDescription}}</div>
           <div><b>Violated Rows</b></div>

--- a/inst/shinyApps/www/index.html
+++ b/inst/shinyApps/www/index.html
@@ -113,6 +113,8 @@
 
         <hr class="m-0">
         Apache 2.0 Open Source Software - Brought to you by <a href="http://www.ohdsi.org">OHDSI</a>
+        <br>
+        App Version: <span id="appVersion"></span>
       </div>
     </section>
 

--- a/inst/shinyApps/www/js/loadResults.js
+++ b/inst/shinyApps/www/js/loadResults.js
@@ -152,12 +152,13 @@ function loadResults(results) {
             { data: function (d) { if (d.isError == 1) { return "ERROR" } else if (d.notApplicable == 1) { return "NOT APPLICABLE" } else if (d.failed == 1) { return "FAIL" } else {return "PASS"} }, title: "STATUS", className: 'dt-body-right' },
             /*{ data: function (d) { return d.context ? d.context : "None"; }, title: "CONTEXT" },*/
             { data: "cdmTableName", title: "TABLE"},
-            { data: function (d) { return d.cdmFieldName ? d.cdmFieldName : "None"; }, title: "FIELD", visible: false },
-            { data: "checkName", title: "CHECK", visible: false},
+            { data: function (d) { return d.cdmFieldName ? d.cdmFieldName : "None"; }, title: "FIELD", visible: true },
+            { data: "checkName", title: "CHECK", visible: true},
             { data: "category", title: "CATEGORY" },
-            { data: function (d) { return d.subcategory ? d.subcategory : "None" }, title: "SUBCATEGORY" },
-            { data: "checkLevel", title: "LEVEL" },
-            { data: function (d) { if (d.notesValue == null) { return "None"; } else { return "Exists"; } }, title: "NOTES" },
+            { data: function (d) { return d.subcategory ? d.subcategory : "None" }, title: "SUBCATEGORY", visible: false },
+            { data: "checkLevel", title: "LEVEL", visible: false },
+            { data: "severity", title: "SEVERITY", visible: true },
+            { data: function (d) { if (d.notesValue == null) { return "None"; } else { return "Exists"; } }, title: "NOTES", visible: false },
             
             {
                 data: function (d) {

--- a/inst/shinyApps/www/js/loadResults.js
+++ b/inst/shinyApps/www/js/loadResults.js
@@ -5,6 +5,7 @@ function loadResults(results) {
     var metadata = results.Metadata[0];
     $('cdm-source-name').text(metadata.cdmSourceName);
     $('dq-metadata').attr('data-results', JSON.stringify(metadata));
+    $('#appVersion').text(results.appVersion);
 
     function format(d) {
         errorMessage = '';


### PR DESCRIPTION
First test, retrieves severity from checkDescription upon opening shiny app and shows it in the check results table.

Next step is to add a table which shows counts fails by severity.

Closes #657