### PR TITLE
Add SQL error tests and fix plausibleGender concept handling

### DIFF
--- a/inst/sql/sql_server/concept_plausible_gender.sql
+++ b/inst/sql/sql_server/concept_plausible_gender.sql
@@ -40,7 +40,7 @@ FROM
 				ON cdmTable.person_id = c.subject_id
 				AND c.cohort_definition_id = @cohortDefinitionId
 			}
-		WHERE cdmTable.@cdmFieldName = @conceptId
+		WHERE cdmTable.@cdmFieldName IN (@conceptId)
 		  	AND p.gender_concept_id <> {@plausibleGender == 'Male'} ? {8507} : {8532} 
 		/*violatedRowsEnd*/
 	) violated_rows
@@ -54,6 +54,6 @@ FROM
 		  	ON cdmTable.person_id = c.subject_id
 		  	AND c.cohort_definition_id = @cohortDefinitionId
 	}
-	WHERE @cdmFieldName = @conceptId
+	WHERE @cdmFieldName IN (@conceptId)
 ) denominator
 ;

--- a/tests/testthat/test-executeDqChecks.R
+++ b/tests/testthat/test-executeDqChecks.R
@@ -49,6 +49,9 @@ test_that("Execute all TABLE checks on Synthea/Eunomia", {
   )
 
   expect_true(nrow(results$CheckResults) > 0)
+  
+  sqlErrors <- stats::na.omit(results$CheckResults$error)
+  expect_length(sqlErrors, 0)
 })
 
 test_that("Execute FIELD checks on Synthea/Eunomia", {
@@ -73,6 +76,9 @@ test_that("Execute FIELD checks on Synthea/Eunomia", {
     }
   )
   expect_true(nrow(results$CheckResults) > 0)
+  
+  sqlErrors <- stats::na.omit(results$CheckResults$error)
+  expect_length(sqlErrors, 0)
 })
 
 test_that("Execute CONCEPT checks on Synthea/Eunomia", {
@@ -101,6 +107,9 @@ test_that("Execute CONCEPT checks on Synthea/Eunomia", {
     }
   )
   expect_true(nrow(results$CheckResults) > 0)
+  
+  sqlErrors <- stats::na.omit(results$CheckResults$error)
+  expect_length(sqlErrors, 0)
 })
 
 test_that("Execute observation period overlap check", {


### PR DESCRIPTION
Closes #605

## Summary

Adds test coverage to verify that TABLE, FIELD, and CONCEPT checks
executed against Eunomia do not return SQL errors.

The new CONCEPT assertion exposed an existing SQLite syntax error in the
`plausibleGender` check when multiple concept IDs were supplied.

## Changes

- Added assertions checking `results$CheckResults$error` for TABLE,
  FIELD, and CONCEPT Eunomia tests
- Updated the `plausibleGender` SQL predicates from `= @conceptId`
  to `IN (@conceptId)` to support multiple concept IDs

## Testing

- Ran `testthat::test_file("tests/testthat/test-executeDqChecks.R")`
  - `FAIL 0 | WARN 0 | SKIP 2 | PASS 37`