### PR TITLE
Clean concept level file

### DIFF
--- a/inst/csv/OMOP_CDM_Concept_Level.csv
+++ b/inst/csv/OMOP_CDM_Concept_Level.csv
@@ -290,184 +290,184 @@ CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,"4090861, 4025213","Male genitalia fin
 CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,"4095793 , 443343, 4024004 , 4172857, 444094 , 197810, 4158481","Female genitalia finding, Disorder of intrauterine contraceptive device, Menopause finding, Disorder of female genital system, Malignant neoplasm of uterine adnexa, Finding related to pregnancy, Female reproductive finding",,,,,Female,2,,,,
 PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4041261,Procedure on female genital system,,,,,Female,2,,,,
 PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,"4250917, 4077750, 4043199, 4040577","Operation on prostate, Operation on scrotum, Procedure on penis, Procedure on testis",,,,,Male,2,,,,
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006315,Basophils [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004410,Hemoglobin A1c/Hemoglobin.total in Blood,,,,,,,,"8554,8737,9225,9579",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40487382,Total lymphocyte count,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013721,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019198,Lymphocytes [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034426,Prothrombin time (PT),,,,,,,,8555,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3043688,Hemoglobin [Mass/volume] in Body fluid,,,,,,,,"8713,8859",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3046485,Urea nitrogen/Creatinine [Mass Ratio] in Blood,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4216098,Eosinophil count,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4245152,Potassium measurement,,,,,,,,"8736,8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,43055141,Pain severity - 0-10 verbal numeric rating [Score] - Reported,,,,,,,,-1,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006923,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021044,Iron binding capacity [Mass/volume] in Serum or Plasma,,,,,,,,8837,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024171,Respiratory rate,,,,,,,,"8483,8541",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027114,Cholesterol [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762499,Oxygen saturation in Arterial blood by Pulse oximetry,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000963,Hemoglobin [Mass/volume] in Blood,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001604,Monocytes [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019069,Monocytes/100 leukocytes in Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022509,Hyaline casts [#/area] in Urine sediment by Microscopy low power field,,,,,,,,8765,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028288,Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4148615,Neutrophil count,,,,,,,,"8784,8848,8961,8848,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,44806420,Estimation of glomerular filtration rate,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028437,Cholesterol in LDL [Mass/volume] in Serum or Plasma,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,,,,,,,,8837,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026925,Triiodothyronine (T3) Free [Mass/volume] in Serum or Plasma,,,,,,,,"8820,8845",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028615,Eosinophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3051205,Crystals [#/area] in Urine sediment by Microscopy high power field,,,,,,,,8786,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4098046,Pulse oximetry,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005131,Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011163,Cholesterol.total/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8529,8554,8596,8606,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3044491,Cholesterol non HDL [Mass/volume] in Serum or Plasma,,,,,,,,"8576,8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4017361,Blood urea nitrogen measurement,,,,,,,,"8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006504,Eosinophils/100 leukocytes in Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000483,Glucose [Mass/volume] in Blood,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033543,Specific gravity of Urine,,,,,,,,"8523,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3045716,Anion gap in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4101713,High density lipoprotein cholesterol measurement,,,,,,,,"8636,8736,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4103762,Anion gap measurement,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001008,Epithelial cells.squamous [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8765,8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009744,MCHC [Mass/volume] by Automated count,,,,,,,,"8564,8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013115,Eosinophils [#/volume] in Blood,,,,,,,,"8848,8961,9444,8784,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019550,Sodium [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020416,Erythrocytes [#/volume] in Blood by Automated count,,,,,,,,"44777575,8734,8815,8647,8931,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035995,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3038553,Body mass index (BMI) [Ratio],,,,,,,,9531,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,35610320,Diastolic arterial pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001490,Nucleated erythrocytes [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4195214,Cholesterol/HDL ratio measurement,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,36306178,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393850,MCHC - Mean corpuscular haemoglobin concentration,,,,,,,,"8636,8713,8554,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004501,Glucose [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008598,Thyroxine (T4) free [Mass/volume] in Serum or Plasma,,,,,,,,"8817,8845,8725",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018010,Neutrophils/100 leukocytes in Blood,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022192,Triglyceride [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151768,Pack years,,,,,,,,"9448,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197602,Serum TSH measurement,,,,,,,,"8719,9040,9093,44777578,8750,8923,44777583",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006906,Calcium [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007070,Cholesterol in HDL [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020460,C reactive protein [Mass/volume] in Serum or Plasma,,,,,,,,"8751,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023314,Hematocrit [Volume Fraction] of Blood by Automated count,,,,,,,,"44777604,8554",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035941,MCH [Entitic mass],,,,,,,,"8564,9655",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037072,Urobilinogen [Mass/volume] in Urine by Test strip,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151358,Hematocrit determination,,,,,,,,"44777604,8554,8523",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4194332,Monocyte count,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001123,Platelet mean volume [Entitic volume] in Blood,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012888,Diastolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013707,Erythrocyte sedimentation rate by Westergren method,,,,,,,,8752,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037511,Lymphocytes/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3040168,Immature granulocytes [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4097430,Sodium measurement,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005424,Body surface area,,,,,,,,8617,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013603,Prostate specific Ag [Mass/volume] in Serum or Plasma,,,,,,,,"8748,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020509,Albumin/Globulin [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036277,Body height,,,,,,,,"8582,9327,9330,9546",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4301868,Pulse rate,,,,,,,,"8483,8541,8581",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762636,Body mass index (BMI) [Percentile],,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40765040,25-Hydroxyvitamin D3+25-Hydroxyvitamin D2 [Mass/volume] in Serum or Plasma,,,,,,,,"8842,8845",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024386,Platelet mean volume [Entitic volume] in Blood by Rees-Ecker,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009201,Thyrotropin [Units/volume] in Serum or Plasma,,,,,,,,"44777578,8719,9040,9093,8860",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024731,MCV [Entitic volume],,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3050479,Immature granulocytes/100 leukocytes in Blood,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4012479,Low density lipoprotein cholesterol measurement,,,,,,,,"8636,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4152194,Systolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393840,Haematocrit,,,,,,,,"44777604,8523,8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,,,,,,,,"8845,8725",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002888,Erythrocyte distribution width [Entitic volume],,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010910,Erythrocytes [#/volume] in Body fluid,,,,,,,,"8647,8785,8815,8931,8784,8848,9257,8888,9428",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013290,Carbon dioxide [Partial pressure] in Blood,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027970,Globulin [Mass/volume] in Serum by calculation,,,,,,,,"8636,8713,8950",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4239408,Heart rate,,,,,,,,"8483,8541,8581",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010813,Leukocytes [#/volume] in Blood,,,,,,,,"44777588,8848,8961,9444,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023103,Potassium [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4030871,Red blood cell count,,,,,,,,"8734,8815,8931,9444,9445",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4154790,Diastolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4217013,Systolic arterial pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001318,Cholesterol.total/Cholesterol in HDL [Percentile],,,,,,,,"8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004249,Systolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009596,Cholesterol in VLDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,"8576,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025315,Body weight,,,,,,,,"8739,9346,9373,9529",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3053283,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4008265,Total cholesterol measurement,,,,,,,,"8736,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,36303797,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398460,Serum alkaline phosphatase level,,,,,,,,"32995,8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026361,Erythrocytes [#/volume] in Blood,,,,,,,,"32706,8785,8815,8931,8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027018,Heart rate,,,,,,,,"8483,8541,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4013965,"Oxygen saturation measurement, arterial",,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013429,Basophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023599,MCV [Entitic volume] by Automated count,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036588,Neutrophil cytoplasmic Ab.perinuclear [Presence] in Serum,,,,,,,,"8525,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4298431,White blood cell count,,,,,,,,"8848,8961,9444,8784,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017732,Neutrophils [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024561,Albumin [Mass/volume] in Serum or Plasma,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034639,Hemoglobin A1c [Mass/volume] in Blood,,,,,,,,"8713,8840,9579,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013650,Neutrophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8848,8961,9444,8647,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021886,Globulin [Mass/volume] in Serum,,,,,,,,"8636,8713,8950",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4254663,Lymphocyte count,,,,,,,,"8848,9444,8961",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001420,Magnesium [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007461,Platelets [#/volume] in Blood,,,,,,,,"8848,8961,9444,32706",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012030,MCH [Entitic mass] by Automated count,,,,,,,,"8564,8704,9655,8504,8576",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40764999,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008893,Testosterone [Mass/volume] in Serum or Plasma,,,,,,,,"8817,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016723,Creatinine [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8749",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026910,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033575,Monocytes [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3041084,Immature granulocytes [#/volume] in Blood by Automated count,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4184637,Hemoglobin A1c measurement,,,,,,,,"8554,8632,8737,9579",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4313591,Respiratory rate,,,,,,,,"8483,8541",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393851,MCV - Mean corpuscular volume,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,1619025,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI 2021)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013869,Basophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035472,Albumin/Protein.total in Serum or Plasma,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3039000,Anion gap in Blood,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000905,Leukocytes [#/volume] in Blood by Automated count,,,,,,,,"8816,8848,8961,9436,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3015632,"Carbon dioxide, total [Moles/volume] in Serum or Plasma",,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3032710,Calcium.ionized/Calcium.total corrected for albumin in Blood,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197971,HbA1c measurement (DCCT aligned),,,,,,,,"8554,8632,8737",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,42869452,Immature granulocytes/100 leukocytes in Blood by Automated count,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002109,Cholesterol in LDL/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8596,8606,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004327,Lymphocytes [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006322,Oral temperature,,,,,,,,"586323,9289",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008342,Neutrophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020630,Protein [Mass/volume] in Serum or Plasma,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001122,Ferritin [Mass/volume] in Serum or Plasma,,,,,,,,"8748,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009542,Hematocrit [Volume Fraction] of Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010189,Epithelial cells [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8765,8786",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010457,Eosinophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4192368,Platelet mean volume determination,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3014576,Chloride [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024128,Bilirubin.total [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8749",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018311,Urea nitrogen/Creatinine [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020891,Body temperature,,,,,,,,"586323,9289",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037556,Urate [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37399332,Serum TSH (thyroid stimulating hormone) level,,,,,,,,"44777578,9040",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011904,Phosphate [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019897,Erythrocyte distribution width [Ratio] by Automated count,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025255,Bacteria [#/area] in Urine sediment by Microscopy high power field,,,,,,,,8786,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4076704,High density lipoprotein measurement,,,,,,,,"8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4172647,Basophil count,,,,,,,,"8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393531,Serum alanine aminotransferase level,,,,,,,,"32995,8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40771529,Immature granulocytes/100 leukocytes in Body fluid,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000034,Microalbumin [Mass/volume] in Urine,,,,,,,,"8576,8723,8751,8840,8859,8636",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035124,Erythrocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002030,Lymphocytes/100 leukocytes in Blood,,,,,,,,"8554,8848",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019170,Thyrotropin [Units/volume] in Serum or Plasma by Detection limit <= 0.005 mIU/L,,,,,,,,"44777578,8719,8860,9040,9093,9550",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020149,25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma,,,,,,,,8842,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022174,Leukocytes [#/volume] in Body fluid,,,,,,,,"8647,8784,8785,8848,8961,9257,8888",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024929,Platelets [#/volume] in Blood by Automated count,,,,,,,,"8816,8848,8961,9436,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3049187,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398676,Basophil count,,,,,,,,8848,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4112223,BUN/Creatinine ratio,,,,,,,,"8523,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017250,Creatinine [Mass/volume] in Urine,,,,,,,,"8840,8636",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4191837,Calculated LDL cholesterol level,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022096,Basophils/100 leukocytes in Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034485,Albumin/Creatinine [Mass Ratio] in Urine,,,,,,,,"8523,8723,8838,9017,9072",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,44790183,Glomerular filtration rate testing,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002400,Iron [Mass/volume] in Serum or Plasma,,,,,,,,"8749,8837",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3003338,MCHC [Mass/volume],,,,,,,,"8713,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006315,Basophils [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004410,Hemoglobin A1c/Hemoglobin.total in Blood,,,,,,,,"8554,8737,9225,9579",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40487382,Total lymphocyte count,,,,,,,,"8784,8848,8961,9444,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013721,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019198,Lymphocytes [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034426,Prothrombin time (PT),,,,,,,,8555,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3043688,Hemoglobin [Mass/volume] in Body fluid,,,,,,,,"8713,8859",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3046485,Urea nitrogen/Creatinine [Mass Ratio] in Blood,,,,,,,,"8523,8554,8596,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4216098,Eosinophil count,,,,,,,,"8784,8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4245152,Potassium measurement,,,,,,,,"8736,8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,43055141,Pain severity - 0-10 verbal numeric rating [Score] - Reported,,,,,,,,-1,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006923,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021044,Iron binding capacity [Mass/volume] in Serum or Plasma,,,,,,,,8837,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024171,Respiratory rate,,,,,,,,"8483,8541",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027114,Cholesterol [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762499,Oxygen saturation in Arterial blood by Pulse oximetry,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000963,Hemoglobin [Mass/volume] in Blood,,,,,,,,"8636,8713",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001604,Monocytes [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019069,Monocytes/100 leukocytes in Blood,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022509,Hyaline casts [#/area] in Urine sediment by Microscopy low power field,,,,,,,,8765,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028288,Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,"8840,9028",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4148615,Neutrophil count,,,,,,,,"8784,8848,8961,8848,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,44806420,Estimation of glomerular filtration rate,,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028437,Cholesterol in LDL [Mass/volume] in Serum or Plasma,,,,,,,,"8840,9028",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,,,,,,,,8837,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026925,Triiodothyronine (T3) Free [Mass/volume] in Serum or Plasma,,,,,,,,"8820,8845",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028615,Eosinophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8647",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3051205,Crystals [#/area] in Urine sediment by Microscopy high power field,,,,,,,,8786,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4098046,Pulse oximetry,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005131,Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin,,,,,,,,"8840,9028",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011163,Cholesterol.total/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8529,8554,8596,8606,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3044491,Cholesterol non HDL [Mass/volume] in Serum or Plasma,,,,,,,,"8576,8840,9028",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4017361,Blood urea nitrogen measurement,,,,,,,,"8753,8840",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006504,Eosinophils/100 leukocytes in Blood,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000483,Glucose [Mass/volume] in Blood,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033543,Specific gravity of Urine,,,,,,,,"8523,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3045716,Anion gap in Serum or Plasma,,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4101713,High density lipoprotein cholesterol measurement,,,,,,,,"8636,8736,8753,8840",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4103762,Anion gap measurement,,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001008,Epithelial cells.squamous [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8765,8786,8889",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009744,MCHC [Mass/volume] by Automated count,,,,,,,,"8564,8636,8713",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013115,Eosinophils [#/volume] in Blood,,,,,,,,"8848,8961,9444,8784,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019550,Sodium [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020416,Erythrocytes [#/volume] in Blood by Automated count,,,,,,,,"44777575,8734,8815,8647,8931,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8786,8889",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035995,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3038553,Body mass index (BMI) [Ratio],,,,,,,,9531,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,35610320,Diastolic arterial pressure,,,,,,,,8876,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001490,Nucleated erythrocytes [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4195214,Cholesterol/HDL ratio measurement,,,,,,,,"8523,8554,8596,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,36306178,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393850,MCHC - Mean corpuscular haemoglobin concentration,,,,,,,,"8636,8713,8554,8753",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004501,Glucose [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8753",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008598,Thyroxine (T4) free [Mass/volume] in Serum or Plasma,,,,,,,,"8817,8845,8725",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018010,Neutrophils/100 leukocytes in Blood,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022192,Triglyceride [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8753",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151768,Pack years,,,,,,,,"9448,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197602,Serum TSH measurement,,,,,,,,"8719,9040,9093,44777578,8750,8923,44777583",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006906,Calcium [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007070,Cholesterol in HDL [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020460,C reactive protein [Mass/volume] in Serum or Plasma,,,,,,,,"8751,8840",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023314,Hematocrit [Volume Fraction] of Blood by Automated count,,,,,,,,"44777604,8554",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035941,MCH [Entitic mass],,,,,,,,"8564,9655",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037072,Urobilinogen [Mass/volume] in Urine by Test strip,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151358,Hematocrit determination,,,,,,,,"44777604,8554,8523",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4194332,Monocyte count,,,,,,,,"8784,8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001123,Platelet mean volume [Entitic volume] in Blood,,,,,,,,8583,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012888,Diastolic blood pressure,,,,,,,,8876,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013707,Erythrocyte sedimentation rate by Westergren method,,,,,,,,8752,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037511,Lymphocytes/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3040168,Immature granulocytes [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4097430,Sodium measurement,,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005424,Body surface area,,,,,,,,8617,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013603,Prostate specific Ag [Mass/volume] in Serum or Plasma,,,,,,,,"8748,8842",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020509,Albumin/Globulin [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8554,8596,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036277,Body height,,,,,,,,"8582,9327,9330,9546",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4301868,Pulse rate,,,,,,,,"8483,8541,8581",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762636,Body mass index (BMI) [Percentile],,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40765040,25-Hydroxyvitamin D3+25-Hydroxyvitamin D2 [Mass/volume] in Serum or Plasma,,,,,,,,"8842,8845",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024386,Platelet mean volume [Entitic volume] in Blood by Rees-Ecker,,,,,,,,8583,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009201,Thyrotropin [Units/volume] in Serum or Plasma,,,,,,,,"44777578,8719,9040,9093,8860",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024731,MCV [Entitic volume],,,,,,,,8583,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3050479,Immature granulocytes/100 leukocytes in Blood,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4012479,Low density lipoprotein cholesterol measurement,,,,,,,,"8636,8753,8840",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4152194,Systolic blood pressure,,,,,,,,8876,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393840,Haematocrit,,,,,,,,"44777604,8523,8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,,,,,,,,"8845,8725",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002888,Erythrocyte distribution width [Entitic volume],,,,,,,,8583,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010910,Erythrocytes [#/volume] in Body fluid,,,,,,,,"8647,8785,8815,8931,8784,8848,9257,8888,9428",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013290,Carbon dioxide [Partial pressure] in Blood,,,,,,,,8876,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027970,Globulin [Mass/volume] in Serum by calculation,,,,,,,,"8636,8713,8950",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4239408,Heart rate,,,,,,,,"8483,8541,8581",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010813,Leukocytes [#/volume] in Blood,,,,,,,,"44777588,8848,8961,9444,8647",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023103,Potassium [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4030871,Red blood cell count,,,,,,,,"8734,8815,8931,9444,9445",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4154790,Diastolic blood pressure,,,,,,,,8876,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4217013,Systolic arterial pressure,,,,,,,,8876,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001318,Cholesterol.total/Cholesterol in HDL [Percentile],,,,,,,,"8554,8596,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004249,Systolic blood pressure,,,,,,,,8876,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009596,Cholesterol in VLDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,"8576,8840",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025315,Body weight,,,,,,,,"8739,9346,9373,9529",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3053283,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4008265,Total cholesterol measurement,,,,,,,,"8736,8753,8840",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,36303797,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398460,Serum alkaline phosphatase level,,,,,,,,"32995,8645,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026361,Erythrocytes [#/volume] in Blood,,,,,,,,"32706,8785,8815,8931,8784,8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027018,Heart rate,,,,,,,,"8483,8541,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4013965,"Oxygen saturation measurement, arterial",,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013429,Basophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023599,MCV [Entitic volume] by Automated count,,,,,,,,8583,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036588,Neutrophil cytoplasmic Ab.perinuclear [Presence] in Serum,,,,,,,,"8525,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4298431,White blood cell count,,,,,,,,"8848,8961,9444,8784,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017732,Neutrophils [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024561,Albumin [Mass/volume] in Serum or Plasma,,,,,,,,"8636,8713",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034639,Hemoglobin A1c [Mass/volume] in Blood,,,,,,,,"8713,8840,9579,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013650,Neutrophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8848,8961,9444,8647,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021886,Globulin [Mass/volume] in Serum,,,,,,,,"8636,8713,8950",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4254663,Lymphocyte count,,,,,,,,"8848,9444,8961",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001420,Magnesium [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007461,Platelets [#/volume] in Blood,,,,,,,,"8848,8961,9444,32706",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012030,MCH [Entitic mass] by Automated count,,,,,,,,"8564,8704,9655,8504,8576",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40764999,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008893,Testosterone [Mass/volume] in Serum or Plasma,,,,,,,,"8817,8842",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016723,Creatinine [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8749",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026910,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033575,Monocytes [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785,8647",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3041084,Immature granulocytes [#/volume] in Blood by Automated count,,,,,,,,"8848,8961,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4184637,Hemoglobin A1c measurement,,,,,,,,"8554,8632,8737,9579",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4313591,Respiratory rate,,,,,,,,"8483,8541",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393851,MCV - Mean corpuscular volume,,,,,,,,8583,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,1619025,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI 2021)",,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013869,Basophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035472,Albumin/Protein.total in Serum or Plasma,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3039000,Anion gap in Blood,,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000905,Leukocytes [#/volume] in Blood by Automated count,,,,,,,,"8816,8848,8961,9436,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3015632,"Carbon dioxide, total [Moles/volume] in Serum or Plasma",,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3032710,Calcium.ionized/Calcium.total corrected for albumin in Blood,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197971,HbA1c measurement (DCCT aligned),,,,,,,,"8554,8632,8737",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,42869452,Immature granulocytes/100 leukocytes in Blood by Automated count,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002109,Cholesterol in LDL/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8596,8606,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004327,Lymphocytes [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006322,Oral temperature,,,,,,,,"586323,9289",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008342,Neutrophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020630,Protein [Mass/volume] in Serum or Plasma,,,,,,,,"8636,8713",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001122,Ferritin [Mass/volume] in Serum or Plasma,,,,,,,,"8748,8842",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009542,Hematocrit [Volume Fraction] of Blood,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010189,Epithelial cells [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8765,8786",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010457,Eosinophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4192368,Platelet mean volume determination,,,,,,,,8583,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3014576,Chloride [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024128,Bilirubin.total [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8749",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018311,Urea nitrogen/Creatinine [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8554,8596,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020891,Body temperature,,,,,,,,"586323,9289",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037556,Urate [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37399332,Serum TSH (thyroid stimulating hormone) level,,,,,,,,"44777578,9040",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011904,Phosphate [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019897,Erythrocyte distribution width [Ratio] by Automated count,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025255,Bacteria [#/area] in Urine sediment by Microscopy high power field,,,,,,,,8786,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4076704,High density lipoprotein measurement,,,,,,,,"8753,8840",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4172647,Basophil count,,,,,,,,"8848,8961,9444,8785",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393531,Serum alanine aminotransferase level,,,,,,,,"32995,8645,8923",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40771529,Immature granulocytes/100 leukocytes in Body fluid,,,,,,,,"8554,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000034,Microalbumin [Mass/volume] in Urine,,,,,,,,"8576,8723,8751,8840,8859,8636",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035124,Erythrocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8786,8889",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002030,Lymphocytes/100 leukocytes in Blood,,,,,,,,"8554,8848",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019170,Thyrotropin [Units/volume] in Serum or Plasma by Detection limit <= 0.005 mIU/L,,,,,,,,"44777578,8719,8860,9040,9093,9550",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020149,25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma,,,,,,,,8842,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022174,Leukocytes [#/volume] in Body fluid,,,,,,,,"8647,8784,8785,8848,8961,9257,8888",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024929,Platelets [#/volume] in Blood by Automated count,,,,,,,,"8816,8848,8961,9436,9444",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3049187,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398676,Basophil count,,,,,,,,8848,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4112223,BUN/Creatinine ratio,,,,,,,,"8523,8596,-1",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017250,Creatinine [Mass/volume] in Urine,,,,,,,,"8840,8636",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4191837,Calculated LDL cholesterol level,,,,,,,,"8840,8753",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022096,Basophils/100 leukocytes in Blood,,,,,,,,8554,5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034485,Albumin/Creatinine [Mass Ratio] in Urine,,,,,,,,"8523,8723,8838,9017,9072",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,44790183,Glomerular filtration rate testing,,,,,,,,"720870,8795",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002400,Iron [Mass/volume] in Serum or Plasma,,,,,,,,"8749,8837",5,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3003338,MCHC [Mass/volume],,,,,,,,"8713,8753",5,

--- a/inst/csv/OMOP_CDM_Concept_Level.csv
+++ b/inst/csv/OMOP_CDM_Concept_Level.csv
@@ -1,528 +1,473 @@
-cdmTableName,cdmFieldName,conceptId,conceptName,unitConceptId,unitConceptName,plausibleValueLow,plausibleValueLowThreshold,plausibleValueLowNotes,plausibleValueHigh,plausibleValueHighThreshold,plausibleValueHighNotes,plausibleGender,plausibleGenderUseDescendants,plausibleGenderThreshold,plausibleGenderUseDescendantsThreshold,plausibleGenderNotes,isTemporallyConstant,isTemporallyConstantThreshold,isTemporallyConstantNotes,validPrevalenceLow,validPrevalenceLowThreshold,validPrevalenceLowNotes,validPrevalenceHigh,validPrevalenceHighThreshold,validPrevalenceHighNotes,plausibleUnitConceptIds,plausibleUnitConceptIdsThreshold,plausibleUnitConceptIdsNotes
-VISIT_OCCURRENCE,VISIT_CONCEPT_ID,9201,Inpatient visit,,,,,,,,,,,,,,Yes,,,,,,,,,,,
-VISIT_OCCURRENCE,VISIT_CONCEPT_ID,9202,Outpatient visit,,,,,,,,,,,,,,Yes,,,,,,,,,,,
-VISIT_OCCURRENCE,VISIT_CONCEPT_ID,9203,ER visit,,,,,,,,,,,,,,Yes,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,26662,Testicular hypofunction,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,26935,Disorder of endocrine testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,30969,Testicular hyperfunction,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,73801,Scrotal varices,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,74322,Benign neoplasm of scrotum,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,78193,Orchitis and epididymitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,79758,Primary malignant neoplasm of scrotum,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,80180,Osteoarthritis,,,,,,,,,,,,,,Yes,,,0.0584,,,0.5252,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,80809,Rheumatoid arthritis,,,,,,,,,,,,,,Yes,,,0.0045,,,0.0405,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,81893,Ulcerative colitis,,,,,,,,,,,,,,Yes,,,0.0014,,,0.0128,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,81902,Urinary tract infectious disease,,,,,,,,,,,,,,Yes,,,0.0412,,,0.371,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,140168,Psoriasis,,,,,,,,,,,,,,Yes,,,0.0055,,,0.0494,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,141917,Balanitis xerotica obliterans,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192367,Dysplasia of cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192671,Gastrointestinal hemorrhage,,,,,,,,,,,,,,Yes,,,0.0135,,,0.1219,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192676,Cervical intraepithelial neoplasia grade 1,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192683,Uterovaginal prolapse,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192854,Intramural leiomyoma of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192858,Ovarian hyperfunction,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193254,Disorder of vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193261,Vaginospasm,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193262,Inflammatory disorder of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193277,Deliveries by cesarean,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193437,Neoplasm of uncertain behavior of female genital organ,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193439,Benign neoplasm of body of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193522,Acute prostatitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193530,Follicular cyst of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193739,Ovarian failure,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193818,Calculus of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194092,Uterine prolapse without vaginal wall prolapse,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194286,"Malignant neoplasm of corpus uteri, excluding isthmus",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194412,Dysplasia of vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194420,Endometriosis of fallopian tube,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194611,Carcinoma in situ of uterine cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194696,Dysmenorrhea,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194871,Trichomonal vulvovaginitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194997,Prostatitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195009,Leukoplakia of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195012,Intermenstrual bleeding - irregular,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195197,Primary malignant neoplasm of vulva,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195316,Atypical endometrial hyperplasia,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195321,Postmenopausal bleeding,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195483,Primary malignant neoplasm of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195500,Benign neoplasm of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195501,Polycystic ovaries,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195683,Open wound of penis without complication,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195769,Submucous leiomyoma of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195770,Subserous leiomyoma of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195793,Neoplasm of uncertain behavior of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195867,Noninflammatory disorder of the vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195873,Leukorrhea,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196048,Primary malignant neoplasm of vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196051,Overlapping malignant neoplasm of female genital organs,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196068,Carcinoma in situ of male genital organ,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196157,Induratio penis plastica,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196158,Disorder of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196163,Cervicitis and endocervicitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196165,Cervical intraepithelial neoplasia grade 2,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196168,Irregular periods,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196359,Primary malignant neoplasm of uterine cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196364,Benign neoplasm of uterine cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196473,Hypertrophy of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196734,Disorder of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196738,Disorder of male genital organ,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196758,Tumor of body of uterus affecting pregnancy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197032,Hyperplasia of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197039,Male genital organ vascular diseases,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197044,Female infertility associated with anovulation,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197236,Uterine leiomyoma,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197237,Benign neoplasm of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197494,Viral hepatitis C,,,,,,,,,,,,,,Yes,,,0.0017,,,0.0155,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197507,Primary malignant neoplasm of male genital organ,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197508,Malignant tumor of urinary bladder,,,,,,,,,,,,,,Yes,,,0.0013,,,0.0113,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197601,Spermatocele,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197605,Inflammatory disorder of male genital organ,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197606,Female infertility of tubal origin,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197607,Excessive and frequent menstruation,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197609,"Cervical, vaginal and vulval inflammatory diseases",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197610,Cyst of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197938,Uterine inertia,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198082,Overlapping malignant neoplasm of body of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198108,Benign neoplasm of fallopian tubes and uterine ligaments,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198194,Female genital organ symptoms,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198197,Male infertility,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198198,Polyp of vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198202,Cystocele,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198212,Spotting per vagina in pregnancy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198363,Candidiasis of vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198471,Complex endometrial hyperplasia,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198483,Stricture or atresia of the vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198803,Benign prostatic hyperplasia,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198806,Abscess of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199067,Female pelvic inflammatory disease,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199078,Vaginal wall prolapse,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199752,Secondary malignant neoplasm of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199764,Benign neoplasm of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199876,Prolapse of female genital organs,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199877,Mucous polyp of cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199878,Light and infrequent menstruation,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199881,Endometriosis of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200051,Primary malignant neoplasm of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200052,Primary malignant neoplasm of uterine adnexa,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200147,Atrophy of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200445,Chronic prostatitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200452,Disorder of female genital organs,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200461,Endometriosis of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200670,Benign neoplasm of male genital organ,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200675,Neoplasm of uncertain behavior of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200775,Endometrial hyperplasia,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200779,Polyp of corpus uteri,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200780,Disorder of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200962,Primary malignant neoplasm of prostate,,,,,,,,,Male,,5,,,Yes,,,0.0052,,,0.0471,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200970,Carcinoma in situ of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201072,Benign prostatic hypertrophy without outflow obstruction,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201078,Atrophic vaginitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201211,Herpetic vulvovaginitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201238,Primary malignant neoplasm of female genital organ,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201244,Benign neoplasm of vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201257,Disorder of endocrine ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201346,Edema of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201355,Erosion and ectropion of the cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201527,Neoplasm of uncertain behavior of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201606,Crohn's disease,,,,,,,,,,,,,,Yes,,,0.0012,,,0.0112,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201617,Prostatic cyst,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201625,Malposition of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201801,Primary malignant neoplasm of fallopian tube,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201817,Benign neoplasm of female genital organ,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201820,Diabetes mellitus,,,,,,,,,,,,,,Yes,,,0.039,,,0.3514,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201823,Benign neoplasm of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201907,Edema of male genital organs,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201909,Female infertility,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201913,"Torsion of the ovary, ovarian pedicle or fallopian tube",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,255573,Chronic obstructive lung disease,,,,,,,,,,,,,,Yes,,,0.0194,,,0.1742,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,255848,Pneumonia,,,,,,,,,,,,,,Yes,,,0.0218,,,0.1966,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,313217,Atrial fibrillation,,,,,,,,,,,,,,Yes,,,0.0128,,,0.1155,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,314409,Vascular disorder of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,315586,Priapism,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,316139,Heart failure,,,,,,,,,,,,,,Yes,,,0.0161,,,0.1452,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,316866,Hypertensive disorder,,,,,,,,,,,,,,Yes,,,0.0913,,,0.8215,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,317576,Coronary arteriosclerosis,,,,,,,,,,,,,,Yes,,,0.0206,,,0.1852,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,318800,Gastroesophageal reflux disease,,,,,,,,,,,,,,Yes,,,0.0337,,,0.3033,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,321052,Peripheral vascular disease,,,,,,,,,,,,,,Yes,,,0.0426,,,0.3832,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,321588,Heart disease,,,,,,,,,,,,,,Yes,,,0.061,,,0.5491,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,381591,Cerebrovascular disease,,,,,,,,,,,,,,Yes,,,0.0142,,,0.1274,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,432571,Malignant lymphoma,,,,,,,,,,,,,,Yes,,,0.0016,,,0.0143,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,432867,Hyperlipidemia,,,,,,,,,,,,,,Yes,,,0.0712,,,0.6412,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,433716,Primary malignant neoplasm of testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,433736,Obesity,,,,,,,,,,,,,,Yes,,,0.038,,,0.3422,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,434251,Injury of male external genital organs,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,435315,Torsion of testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,435648,Retractile testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,435783,Schizophrenia,,,,,,,,,,,,,,Yes,,,0.0021,,,0.0186,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436155,Redundant prepuce and phimosis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436358,Primary malignant neoplasm of exocervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436366,Benign neoplasm of testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436466,Balanoposthitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,437501,Primary malignant neoplasm of labia majora,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,437655,Undescended testicle,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,438409,Attention deficit hyperactivity disorder,,,,,,,,,,,,,,Yes,,,0.0078,,,0.0706,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,438477,Atrophy of testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,439727,Human immunodeficiency virus infection,,,,,,,,,,,,,,Yes,,,0.0006,,,0.0057,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,439871,Hemospermia,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,440383,Depressive disorder,,,,,,,,,,,,,,Yes,,,0.0392,,,0.3531,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,440417,Pulmonary embolism,,,,,,,,,,,,,,Yes,,,0.0024,,,0.022,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,440971,Neoplasm of uncertain behavior of testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,441068,Torsion of appendix of testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,441077,Stenosis of cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,441805,Primary malignant neoplasm of endocervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,442781,Disorder of uterine cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443211,Benign prostatic hypertrophy with outflow obstruction,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443388,Malignant tumor of lung,,,,,,,,,,,,,,Yes,,,0.0021,,,0.0185,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443392,Malignant neoplastic disease,,,,,,,,,,,,,,Yes,,,0.0326,,,0.2932,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443435,Primary uterine inertia,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443800,Amenorrhea,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,444078,Inflammation of cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,444106,Candidiasis of vulva,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,444247,Venous thrombosis,,,,,,,,,,,,,,Yes,,,0.0082,,,0.0737,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2003947,Closed [percutaneous] [needle] biopsy of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2003966,Other transurethral prostatectomy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2003983,Other prostatectomy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004031,Other repair of scrotum and tunica vaginalis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004063,Unilateral orchiectomy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004070,Other repair of testis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004090,Excision of varicocele and hydrocele of spermatic cord,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004164,Local excision or destruction of lesion of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004263,Other removal of both ovaries and tubes at same operative episode,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004329,Other bilateral destruction or occlusion of fallopian tubes,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004342,Removal of both fallopian tubes at same operative episode,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004443,Closed biopsy of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004627,Vaginal suspension and fixation,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109825,"Transurethral electrosurgical resection of prostate, including control of postoperative bleeding, complete (vasectomy, meatotomy, cystourethroscopy, urethral calibration and/or dilation, and internal urethrotomy are included)",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109833,"Laser vaporization of prostate, including control of postoperative bleeding, complete (vasectomy, meatotomy, cystourethroscopy, urethral calibration and/or dilation, internal urethrotomy and transurethral resection of prostate are included if performed)",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109900,"Destruction of lesion(s), penis (eg, condyloma, papilloma, molluscum contagiosum, herpetic vesicle), simple; chemical",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109902,"Destruction of lesion(s), penis (eg, condyloma, papilloma, molluscum contagiosum, herpetic vesicle), simple; cryosurgery",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109905,"Destruction of lesion(s), penis (eg, condyloma, papilloma, molluscum contagiosum, herpetic vesicle), extensive (eg, laser surgery, electrosurgery, cryosurgery, chemosurgery)",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109906,"Biopsy of penis, (separate procedure)",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109916,"Circumcision, using clamp or other device with regional dorsal penile or ring block",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109968,Foreskin manipulation including lysis of preputial adhesions and stretching,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109973,"Orchiectomy, simple (including subcapsular), with or without testicular prosthesis, scrotal or inguinal approach",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109981,"Orchiopexy, inguinal approach, with or without hernia repair",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110004,Drainage of scrotal wall abscess,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110011,"Vasectomy, unilateral or bilateral (separate procedure), including postoperative semen examination(s)",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110026,"Biopsy, prostate; needle or punch, single or multiple, any approach",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110039,"Prostatectomy, retropubic radical, with or without nerve sparing; with bilateral pelvic lymphadenectomy, including external iliac, hypogastric, and obturator nodes",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110044,"Laparoscopy, surgical prostatectomy, retropubic radical, including nerve sparing, includes robotic assistance, when performed",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110078,Colposcopy of the vulva,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110116,"Colpopexy, vaginal; extra-peritoneal approach (sacrospinous, iliococcygeus)",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110142,"Laparoscopy, surgical, colpopexy (suspension of vaginal apex)",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110144,"Colposcopy of the cervix including upper/adjacent vagina, with biopsy(s) of the cervix and endocervical curettage",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110169,"Endometrial sampling (biopsy) with or without endocervical sampling (biopsy), without cervical dilation, any method (separate procedure)",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110175,"Total abdominal hysterectomy (corpus and cervix), with or without removal of tube(s), with or without removal of ovary(s)",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110194,Insertion of intrauterine device (IUD),,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110195,Removal of intrauterine device (IUD),,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110203,"Endometrial ablation, thermal, without hysteroscopic guidance",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110222,"Hysteroscopy, surgical; with sampling (biopsy) of endometrium and/or polypectomy, with or without D & C",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110227,"Hysteroscopy, surgical; with endometrial ablation (eg, endometrial resection, electrosurgical ablation, thermoablation)",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110230,"Laparoscopy, surgical, with total hysterectomy, for uterus 250 g or less; with removal of tube(s) and/or ovary(s)",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110307,"Routine obstetric care including antepartum care, vaginal delivery (with or without episiotomy, and/or forceps) and postpartum care",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110315,"Routine obstetric care including antepartum care, cesarean delivery, and postpartum care",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110316,Cesarean delivery only,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110317,"Cesarean delivery only, including postpartum care",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110326,"Treatment of missed abortion, completed surgically; first trimester",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211747,"Ultrasound, pregnant uterus, real time with image documentation, fetal and maternal evaluation, first trimester (< 14 weeks 0 days), transabdominal approach; single or first gestation",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211749,"Ultrasound, pregnant uterus, real time with image documentation, fetal and maternal evaluation, after first trimester (> or = 14 weeks 0 days), transabdominal approach; single or first gestation",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211751,"Ultrasound, pregnant uterus, real time with image documentation, fetal and maternal evaluation plus detailed fetal anatomic examination, transabdominal approach; single or first gestation",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211753,"Ultrasound, pregnant uterus, real time with image documentation, first trimester fetal nuchal translucency measurement, transabdominal or transvaginal approach; single or first gestation",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211755,"Ultrasound, pregnant uterus, real time with image documentation, limited (eg, fetal heart beat, placental location, fetal position and/or qualitative amniotic fluid volume), 1 or more fetuses",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211756,"Ultrasound, pregnant uterus, real time with image documentation, follow-up (eg, re-evaluation of fetal size by measuring standard growth parameters and amniotic fluid volume, re-evaluation of organ system(s) suspected or confirmed to be abnormal on a prev",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211757,"Ultrasound, pregnant uterus, real time with image documentation, transvaginal",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211765,"Ultrasound, transvaginal",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211769,"Ultrasound, scrotum and contents",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2617204,"Cervical or vaginal cancer screening, pelvic and clinical breast examination",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2721063,"Annual gynecological examination, new patient",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2721064,"Annual gynecological examination, established patient",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2780478,"Resection of Prostate, Percutaneous Endoscopic Approach",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2780523,"Resection of Prepuce, External Approach",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4005743,Female sterility,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4005933,"Hypospadias, penile",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4006969,Acute respiratory disease,,,,,,,,,,,,,,Yes,,,0.1703,,,1,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4012343,Vaginal discharge symptom,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4016155,Prostatism,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4021531,Total abdominal hysterectomy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4030518,Renal impairment,,,,,,,,,,,,,,Yes,,,0.0174,,,0.1568,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4032594,Inflammation of scrotum,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4032622,Laparoscopic supracervical hysterectomy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4038747,Obstetric examination,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4044013,Hematologic neoplasm,,,,,,,,,,,,,,Yes,,,0.0037,,,0.0331,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4048225,Neoplasm of endometrium,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4050091,Open wound of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4051956,Vulvovaginal disease,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4052532,Hysteroscopy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4054550,Open wound of scrotum and testes,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4056903,Vaginitis associated with another disorder,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4058792,Douche of vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060207,Vulval irritation,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060556,"Uterine scar from previous surgery in pregnancy, childbirth and the puerperium",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060558,"Uterine scar from previous surgery in pregnancy, childbirth and the puerperium - delivered",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060559,"Uterine scar from previous surgery in pregnancy, childbirth and the puerperium with antenatal problem",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4061050,Subacute and chronic vaginitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4071874,Pain in scrotum,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4073700,Transurethral laser prostatectomy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4081648,Acute vaginitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4083772,Echography of scrotum and contents,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4090039,Penile arterial insufficiency,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4092515,"Malignant neoplasm, overlapping lesion of cervix uteri",,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4093346,Large prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4095940,Finding of pattern of menstrual cycle,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4096783,Radical prostatectomy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4104000,Lesion of liver,,,,,,,,,,,,,,Yes,,,0.0029,,,0.0265,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4109081,Pain in penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4112853,Malignant tumor of breast,,,,,,,,,,,,,,Yes,,,0.0047,,,0.0421,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4127886,Hysterectomy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4128329,Menopause present,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4129155,Vaginal bleeding,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4134440,Visual system disorder,,,,,,,,,,,,,,Yes,,,0.1181,,,1,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4138738,Vaginal hysterectomy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4140828,Acute vulvitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4141940,Endometrial ablation,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4143116,Azoospermia,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4146777,Radical abdominal hysterectomy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4147021,"Contusion, scrotum or testis",,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4149084,Vaginitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4150042,Vaginal ulcer,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4150816,Bicornuate uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4155529,Mechanical complication of intrauterine contraceptive device,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4156113,Malignant neoplasm of body of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4161944,Low cervical cesarean section,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4162860,Primary malignant neoplasm of body of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4163261,Malignant tumor of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4171394,Abnormal menstrual cycle,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4171915,Orchitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4180790,Malignant tumor of colon,,,,,,,,,,,,,,Yes,,,0.0019,,,0.0173,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4180978,Vulvovaginitis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4181912,Cone biopsy of cervix,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4182210,Dementia,,,,,,,,,,,,,,Yes,,,0.0086,,,0.0773,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4185932,Ischemic heart disease,,,,,,,,,,,,,,Yes,,,0.0201,,,0.1813,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4194652,Pruritus of vulva,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4199600,Candidal balanitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4212540,Chronic liver disease,,,,,,,,,,,,,,Yes,,,0.0053,,,0.0476,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4234536,Transurethral prostatectomy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4235215,Swelling of testicle,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4238715,Removal of intrauterine device,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4243919,Incision of ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4260520,Balanitis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4270932,Pain in testicle,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4275113,Insertion of intrauterine contraceptive device,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4279309,Substance abuse,,,,,,,,,,,,,,Yes,,,0.0063,,,0.0568,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4279913,Primary ovarian failure,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4281030,Secondary malignant neoplasm of right ovary,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4294393,Ulcer of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4294805,Laparoscopic-assisted vaginal hysterectomy,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4295261,Postmenopausal state,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4303258,Bacterial vaginosis,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4306780,Gynecologic examination,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4310552,Orchidopexy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4320332,Hydrocele of tunica vaginalis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4321575,Lysis of penile adhesions,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4330583,Vasectomy,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4339088,Testicular mass,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40481080,Benign localized hyperplasia of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40481902,Malignant neoplasm of anorectum,,,,,,,,,,,,,,Yes,,,0.001,,,0.0089,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40482030,Dysplasia of prostate,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40482406,Low lying placenta,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40483613,Inflammatory disease of female genital structure,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40490888,Herniation of rectum into vagina,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,42709954,Phimosis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45757415,Benign endometrial hyperplasia,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45766654,Disorder of skin of penis,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45770892,Primary malignant neoplasm of uterus,,,,,,,,,Female,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45772671,Nodular prostate without urinary obstruction,,,,,,,,,Male,,5,,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,"4090861, 4025213","Male genitalia finding, Male reproductive finding",,,,,,,,,,Male,,2,,,,,,,,,,,,,
-CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,"4095793 , 443343, 4024004 , 4172857, 444094 , 197810, 4158481","Female genitalia finding, Disorder of intrauterine contraceptive device, Menopause finding, Disorder of female genital system, Malignant neoplasm of uterine adnexa, Finding related to pregnancy, Female reproductive finding",,,,,,,,,,Female,,2,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4041261,Procedure on female genital system,,,,,,,,,,Female,,2,,,,,,,,,,,,,
-PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,"4250917, 4077750, 4043199, 4040577","Operation on prostate, Operation on scrotum, Procedure on penis, Procedure on testis",,,,,,,,,,Male,,2,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,37393449,Plasma total cholesterol level,8840,milligram per deciliter,50,5,,500,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,37393449,Plasma total cholesterol level,8753,millimole per liter,1,5,,15,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,37397989,Serum total cholesterol level,8840,milligram per deciliter,50,5,,500,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,37397989,Serum total cholesterol level,8753,millimole per liter,1,5,,15,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,44809580,Total cholesterol level,8840,milligram per deciliter,50,5,,500,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,44809580,Total cholesterol level,8753,millimole per liter,1,5,,15,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,37392176,Serum creatinine level,8749,micromole per liter,10,5,,200,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,37392176,Serum creatinine level,8840,milligram per deciliter,0.1,5,,5,5,,,,,,,,,,,,,,,,,,
-OBSERVATION,OBSERVATION_CONCEPT_ID,37392176,Serum creatinine level,8751,milligram per liter,10,5,,30,5,,,,,,,,,,,,,,,,,,
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006315,Basophils [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004410,Hemoglobin A1c/Hemoglobin.total in Blood,,,,,,,,,,,,,,,,,,,,,,,"8554,8737,9225,9579",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40487382,Total lymphocyte count,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013721,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019198,Lymphocytes [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034426,Prothrombin time (PT),,,,,,,,,,,,,,,,,,,,,,,8555,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3043688,Hemoglobin [Mass/volume] in Body fluid,,,,,,,,,,,,,,,,,,,,,,,"8713,8859",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3046485,Urea nitrogen/Creatinine [Mass Ratio] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4216098,Eosinophil count,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4245152,Potassium measurement,,,,,,,,,,,,,,,,,,,,,,,"8736,8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,43055141,Pain severity - 0-10 verbal numeric rating [Score] - Reported,,,,,,,,,,,,,,,,,,,,,,,-1,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006923,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021044,Iron binding capacity [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8837,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024171,Respiratory rate,,,,,,,,,,,,,,,,,,,,,,,"8483,8541",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027114,Cholesterol [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762499,Oxygen saturation in Arterial blood by Pulse oximetry,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000963,Hemoglobin [Mass/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001604,Monocytes [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019069,Monocytes/100 leukocytes in Blood,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022509,Hyaline casts [#/area] in Urine sediment by Microscopy low power field,,,,,,,,,,,,,,,,,,,,,,,8765,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028288,Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,,,,,,,,,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4148615,Neutrophil count,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,8848,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,44806420,Estimation of glomerular filtration rate,,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028437,Cholesterol in LDL [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8837,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026925,Triiodothyronine (T3) Free [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8820,8845",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028615,Eosinophils [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8784,8816,8848,8961,9436,9444,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3051205,Crystals [#/area] in Urine sediment by Microscopy high power field,,,,,,,,,,,,,,,,,,,,,,,8786,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4098046,Pulse oximetry,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005131,Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin,,,,,,,,,,,,,,,,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011163,Cholesterol.total/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8523,8529,8554,8596,8606,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3044491,Cholesterol non HDL [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8576,8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4017361,Blood urea nitrogen measurement,,,,,,,,,,,,,,,,,,,,,,,"8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006504,Eosinophils/100 leukocytes in Blood,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000483,Glucose [Mass/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033543,Specific gravity of Urine,,,,,,,,,,,,,,,,,,,,,,,"8523,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3045716,Anion gap in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4101713,High density lipoprotein cholesterol measurement,,,,,,,,,,,,,,,,,,,,,,,"8636,8736,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4103762,Anion gap measurement,,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001008,Epithelial cells.squamous [#/area] in Urine sediment by Microscopy high power field,,,,,,,,,,,,,,,,,,,,,,,"8765,8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009744,MCHC [Mass/volume] by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8564,8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013115,Eosinophils [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444,8784,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019550,Sodium [Moles/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020416,Erythrocytes [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"44777575,8734,8815,8647,8931,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,,,,,,,,,,,,,,,,"8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035995,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3038553,Body mass index (BMI) [Ratio],,,,,,,,,,,,,,,,,,,,,,,9531,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,35610320,Diastolic arterial pressure,,,,,,,,,,,,,,,,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001490,Nucleated erythrocytes [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4195214,Cholesterol/HDL ratio measurement,,,,,,,,,,,,,,,,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,36306178,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393850,MCHC - Mean corpuscular haemoglobin concentration,,,,,,,,,,,,,,,,,,,,,,,"8636,8713,8554,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004501,Glucose [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008598,Thyroxine (T4) free [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8817,8845,8725",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018010,Neutrophils/100 leukocytes in Blood,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022192,Triglyceride [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151768,Pack years,,,,,,,,,,,,,,,,,,,,,,,"9448,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197602,Serum TSH measurement,,,,,,,,,,,,,,,,,,,,,,,"8719,9040,9093,44777578,8750,8923,44777583",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006906,Calcium [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007070,Cholesterol in HDL [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020460,C reactive protein [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8751,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023314,Hematocrit [Volume Fraction] of Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"44777604,8554",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035941,MCH [Entitic mass],,,,,,,,,,,,,,,,,,,,,,,"8564,9655",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037072,Urobilinogen [Mass/volume] in Urine by Test strip,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151358,Hematocrit determination,,,,,,,,,,,,,,,,,,,,,,,"44777604,8554,8523",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4194332,Monocyte count,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001123,Platelet mean volume [Entitic volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012888,Diastolic blood pressure,,,,,,,,,,,,,,,,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013707,Erythrocyte sedimentation rate by Westergren method,,,,,,,,,,,,,,,,,,,,,,,8752,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037511,Lymphocytes/100 leukocytes in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3040168,Immature granulocytes [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4097430,Sodium measurement,,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005424,Body surface area,,,,,,,,,,,,,,,,,,,,,,,8617,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013603,Prostate specific Ag [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8748,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020509,Albumin/Globulin [Mass Ratio] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036277,Body height,,,,,,,,,,,,,,,,,,,,,,,"8582,9327,9330,9546",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4301868,Pulse rate,,,,,,,,,,,,,,,,,,,,,,,"8483,8541,8581",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762636,Body mass index (BMI) [Percentile],,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40765040,25-Hydroxyvitamin D3+25-Hydroxyvitamin D2 [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8842,8845",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024386,Platelet mean volume [Entitic volume] in Blood by Rees-Ecker,,,,,,,,,,,,,,,,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009201,Thyrotropin [Units/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"44777578,8719,9040,9093,8860",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024731,MCV [Entitic volume],,,,,,,,,,,,,,,,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3050479,Immature granulocytes/100 leukocytes in Blood,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4012479,Low density lipoprotein cholesterol measurement,,,,,,,,,,,,,,,,,,,,,,,"8636,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4152194,Systolic blood pressure,,,,,,,,,,,,,,,,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393840,Haematocrit,,,,,,,,,,,,,,,,,,,,,,,"44777604,8523,8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8845,8725",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002888,Erythrocyte distribution width [Entitic volume],,,,,,,,,,,,,,,,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010910,Erythrocytes [#/volume] in Body fluid,,,,,,,,,,,,,,,,,,,,,,,"8647,8785,8815,8931,8784,8848,9257,8888,9428",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013290,Carbon dioxide [Partial pressure] in Blood,,,,,,,,,,,,,,,,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027970,Globulin [Mass/volume] in Serum by calculation,,,,,,,,,,,,,,,,,,,,,,,"8636,8713,8950",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4239408,Heart rate,,,,,,,,,,,,,,,,,,,,,,,"8483,8541,8581",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010813,Leukocytes [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"44777588,8848,8961,9444,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023103,Potassium [Moles/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4030871,Red blood cell count,,,,,,,,,,,,,,,,,,,,,,,"8734,8815,8931,9444,9445",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4154790,Diastolic blood pressure,,,,,,,,,,,,,,,,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4217013,Systolic arterial pressure,,,,,,,,,,,,,,,,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001318,Cholesterol.total/Cholesterol in HDL [Percentile],,,,,,,,,,,,,,,,,,,,,,,"8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004249,Systolic blood pressure,,,,,,,,,,,,,,,,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009596,Cholesterol in VLDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,,,,,,,,,,,,,,,,"8576,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025315,Body weight,,,,,,,,,,,,,,,,,,,,,,,"8739,9346,9373,9529",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3053283,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4008265,Total cholesterol measurement,,,,,,,,,,,,,,,,,,,,,,,"8736,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,36303797,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398460,Serum alkaline phosphatase level,,,,,,,,,,,,,,,,,,,,,,,"32995,8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026361,Erythrocytes [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"32706,8785,8815,8931,8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027018,Heart rate,,,,,,,,,,,,,,,,,,,,,,,"8483,8541,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4013965,"Oxygen saturation measurement, arterial",,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013429,Basophils [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023599,MCV [Entitic volume] by Automated count,,,,,,,,,,,,,,,,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036588,Neutrophil cytoplasmic Ab.perinuclear [Presence] in Serum,,,,,,,,,,,,,,,,,,,,,,,"8525,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4298431,White blood cell count,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444,8784,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017732,Neutrophils [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024561,Albumin [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034639,Hemoglobin A1c [Mass/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8713,8840,9579,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013650,Neutrophils [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8784,8848,8961,9444,8647,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021886,Globulin [Mass/volume] in Serum,,,,,,,,,,,,,,,,,,,,,,,"8636,8713,8950",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4254663,Lymphocyte count,,,,,,,,,,,,,,,,,,,,,,,"8848,9444,8961",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001420,Magnesium [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007461,Platelets [#/volume] in Blood,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444,32706",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012030,MCH [Entitic mass] by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8564,8704,9655,8504,8576",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40764999,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008893,Testosterone [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8817,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016723,Creatinine [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8840,8749",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026910,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033575,Monocytes [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8784,8816,8848,8961,9436,9444,8785,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3041084,Immature granulocytes [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4184637,Hemoglobin A1c measurement,,,,,,,,,,,,,,,,,,,,,,,"8554,8632,8737,9579",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4313591,Respiratory rate,,,,,,,,,,,,,,,,,,,,,,,"8483,8541",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393851,MCV - Mean corpuscular volume,,,,,,,,,,,,,,,,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,1619025,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI 2021)",,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013869,Basophils/100 leukocytes in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035472,Albumin/Protein.total in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3039000,Anion gap in Blood,,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000905,Leukocytes [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8816,8848,8961,9436,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3015632,"Carbon dioxide, total [Moles/volume] in Serum or Plasma",,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3032710,Calcium.ionized/Calcium.total corrected for albumin in Blood,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197971,HbA1c measurement (DCCT aligned),,,,,,,,,,,,,,,,,,,,,,,"8554,8632,8737",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,42869452,Immature granulocytes/100 leukocytes in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002109,Cholesterol in LDL/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8523,8596,8606,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004327,Lymphocytes [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006322,Oral temperature,,,,,,,,,,,,,,,,,,,,,,,"586323,9289",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008342,Neutrophils/100 leukocytes in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020630,Protein [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001122,Ferritin [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8748,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009542,Hematocrit [Volume Fraction] of Blood,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010189,Epithelial cells [#/area] in Urine sediment by Microscopy high power field,,,,,,,,,,,,,,,,,,,,,,,"8765,8786",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010457,Eosinophils/100 leukocytes in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4192368,Platelet mean volume determination,,,,,,,,,,,,,,,,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3014576,Chloride [Moles/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024128,Bilirubin.total [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8840,8749",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018311,Urea nitrogen/Creatinine [Mass Ratio] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020891,Body temperature,,,,,,,,,,,,,,,,,,,,,,,"586323,9289",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037556,Urate [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8840,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37399332,Serum TSH (thyroid stimulating hormone) level,,,,,,,,,,,,,,,,,,,,,,,"44777578,9040",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011904,Phosphate [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019897,Erythrocyte distribution width [Ratio] by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025255,Bacteria [#/area] in Urine sediment by Microscopy high power field,,,,,,,,,,,,,,,,,,,,,,,8786,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4076704,High density lipoprotein measurement,,,,,,,,,,,,,,,,,,,,,,,"8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4172647,Basophil count,,,,,,,,,,,,,,,,,,,,,,,"8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393531,Serum alanine aminotransferase level,,,,,,,,,,,,,,,,,,,,,,,"32995,8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,40771529,Immature granulocytes/100 leukocytes in Body fluid,,,,,,,,,,,,,,,,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000034,Microalbumin [Mass/volume] in Urine,,,,,,,,,,,,,,,,,,,,,,,"8576,8723,8751,8840,8859,8636",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035124,Erythrocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,,,,,,,,,,,,,,,,"8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002030,Lymphocytes/100 leukocytes in Blood,,,,,,,,,,,,,,,,,,,,,,,"8554,8848",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019170,Thyrotropin [Units/volume] in Serum or Plasma by Detection limit <= 0.005 mIU/L,,,,,,,,,,,,,,,,,,,,,,,"44777578,8719,8860,9040,9093,9550",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020149,25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,8842,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022174,Leukocytes [#/volume] in Body fluid,,,,,,,,,,,,,,,,,,,,,,,"8647,8784,8785,8848,8961,9257,8888",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024929,Platelets [#/volume] in Blood by Automated count,,,,,,,,,,,,,,,,,,,,,,,"8816,8848,8961,9436,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3049187,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398676,Basophil count,,,,,,,,,,,,,,,,,,,,,,,8848,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4112223,BUN/Creatinine ratio,,,,,,,,,,,,,,,,,,,,,,,"8523,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017250,Creatinine [Mass/volume] in Urine,,,,,,,,,,,,,,,,,,,,,,,"8840,8636",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,4191837,Calculated LDL cholesterol level,,,,,,,,,,,,,,,,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022096,Basophils/100 leukocytes in Blood,,,,,,,,,,,,,,,,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034485,Albumin/Creatinine [Mass Ratio] in Urine,,,,,,,,,,,,,,,,,,,,,,,"8523,8723,8838,9017,9072",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,44790183,Glomerular filtration rate testing,,,,,,,,,,,,,,,,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002400,Iron [Mass/volume] in Serum or Plasma,,,,,,,,,,,,,,,,,,,,,,,"8749,8837",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
-MEASUREMENT,MEASUREMENT_CONCEPT_ID,3003338,MCHC [Mass/volume],,,,,,,,,,,,,,,,,,,,,,,"8713,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+cdmTableName,cdmFieldName,conceptId,conceptName,unitConceptId,unitConceptName,plausibleGender,plausibleGenderThreshold,plausibleGenderUseDescendants,plausibleGenderUseDescendantsThreshold,plausibleGenderNotes,plausibleUnitConceptIds,plausibleUnitConceptIdsThreshold,plausibleUnitConceptIdsNotes
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,26662,Testicular hypofunction,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,26935,Disorder of endocrine testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,30969,Testicular hyperfunction,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,73801,Scrotal varices,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,74322,Benign neoplasm of scrotum,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,78193,Orchitis and epididymitis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,79758,Primary malignant neoplasm of scrotum,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,141917,Balanitis xerotica obliterans,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192367,Dysplasia of cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192676,Cervical intraepithelial neoplasia grade 1,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192683,Uterovaginal prolapse,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192854,Intramural leiomyoma of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,192858,Ovarian hyperfunction,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193254,Disorder of vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193261,Vaginospasm,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193262,Inflammatory disorder of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193277,Deliveries by cesarean,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193437,Neoplasm of uncertain behavior of female genital organ,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193439,Benign neoplasm of body of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193522,Acute prostatitis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193530,Follicular cyst of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193739,Ovarian failure,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,193818,Calculus of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194092,Uterine prolapse without vaginal wall prolapse,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194286,"Malignant neoplasm of corpus uteri, excluding isthmus",,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194412,Dysplasia of vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194420,Endometriosis of fallopian tube,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194611,Carcinoma in situ of uterine cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194696,Dysmenorrhea,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194871,Trichomonal vulvovaginitis,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,194997,Prostatitis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195009,Leukoplakia of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195012,Intermenstrual bleeding - irregular,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195197,Primary malignant neoplasm of vulva,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195316,Atypical endometrial hyperplasia,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195321,Postmenopausal bleeding,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195483,Primary malignant neoplasm of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195500,Benign neoplasm of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195501,Polycystic ovaries,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195683,Open wound of penis without complication,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195769,Submucous leiomyoma of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195770,Subserous leiomyoma of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195793,Neoplasm of uncertain behavior of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195867,Noninflammatory disorder of the vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,195873,Leukorrhea,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196048,Primary malignant neoplasm of vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196051,Overlapping malignant neoplasm of female genital organs,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196068,Carcinoma in situ of male genital organ,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196157,Induratio penis plastica,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196158,Disorder of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196163,Cervicitis and endocervicitis,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196165,Cervical intraepithelial neoplasia grade 2,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196168,Irregular periods,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196359,Primary malignant neoplasm of uterine cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196364,Benign neoplasm of uterine cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196473,Hypertrophy of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196734,Disorder of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196738,Disorder of male genital organ,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,196758,Tumor of body of uterus affecting pregnancy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197032,Hyperplasia of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197039,Male genital organ vascular diseases,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197044,Female infertility associated with anovulation,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197236,Uterine leiomyoma,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197237,Benign neoplasm of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197507,Primary malignant neoplasm of male genital organ,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197601,Spermatocele,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197605,Inflammatory disorder of male genital organ,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197606,Female infertility of tubal origin,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197607,Excessive and frequent menstruation,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197609,"Cervical, vaginal and vulval inflammatory diseases",,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197610,Cyst of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,197938,Uterine inertia,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198082,Overlapping malignant neoplasm of body of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198108,Benign neoplasm of fallopian tubes and uterine ligaments,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198194,Female genital organ symptoms,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198197,Male infertility,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198198,Polyp of vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198202,Cystocele,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198212,Spotting per vagina in pregnancy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198363,Candidiasis of vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198471,Complex endometrial hyperplasia,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198483,Stricture or atresia of the vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198803,Benign prostatic hyperplasia,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,198806,Abscess of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199067,Female pelvic inflammatory disease,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199078,Vaginal wall prolapse,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199752,Secondary malignant neoplasm of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199764,Benign neoplasm of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199876,Prolapse of female genital organs,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199877,Mucous polyp of cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199878,Light and infrequent menstruation,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,199881,Endometriosis of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200051,Primary malignant neoplasm of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200052,Primary malignant neoplasm of uterine adnexa,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200147,Atrophy of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200445,Chronic prostatitis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200452,Disorder of female genital organs,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200461,Endometriosis of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200670,Benign neoplasm of male genital organ,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200675,Neoplasm of uncertain behavior of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200775,Endometrial hyperplasia,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200779,Polyp of corpus uteri,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200780,Disorder of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200962,Primary malignant neoplasm of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,200970,Carcinoma in situ of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201072,Benign prostatic hypertrophy without outflow obstruction,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201078,Atrophic vaginitis,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201211,Herpetic vulvovaginitis,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201238,Primary malignant neoplasm of female genital organ,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201244,Benign neoplasm of vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201257,Disorder of endocrine ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201346,Edema of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201355,Erosion and ectropion of the cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201527,Neoplasm of uncertain behavior of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201617,Prostatic cyst,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201625,Malposition of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201801,Primary malignant neoplasm of fallopian tube,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201817,Benign neoplasm of female genital organ,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201823,Benign neoplasm of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201907,Edema of male genital organs,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201909,Female infertility,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,201913,"Torsion of the ovary, ovarian pedicle or fallopian tube",,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,314409,Vascular disorder of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,315586,Priapism,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,433716,Primary malignant neoplasm of testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,434251,Injury of male external genital organs,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,435315,Torsion of testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,435648,Retractile testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436155,Redundant prepuce and phimosis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436358,Primary malignant neoplasm of exocervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436366,Benign neoplasm of testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,436466,Balanoposthitis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,437501,Primary malignant neoplasm of labia majora,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,437655,Undescended testicle,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,438477,Atrophy of testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,439871,Hemospermia,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,440971,Neoplasm of uncertain behavior of testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,441068,Torsion of appendix of testis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,441077,Stenosis of cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,441805,Primary malignant neoplasm of endocervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,442781,Disorder of uterine cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443211,Benign prostatic hypertrophy with outflow obstruction,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443435,Primary uterine inertia,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,443800,Amenorrhea,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,444078,Inflammation of cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,444106,Candidiasis of vulva,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2003947,Closed [percutaneous] [needle] biopsy of prostate,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2003966,Other transurethral prostatectomy,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2003983,Other prostatectomy,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004031,Other repair of scrotum and tunica vaginalis,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004063,Unilateral orchiectomy,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004070,Other repair of testis,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004090,Excision of varicocele and hydrocele of spermatic cord,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004164,Local excision or destruction of lesion of penis,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004263,Other removal of both ovaries and tubes at same operative episode,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004329,Other bilateral destruction or occlusion of fallopian tubes,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004342,Removal of both fallopian tubes at same operative episode,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004443,Closed biopsy of uterus,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2004627,Vaginal suspension and fixation,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109825,"Transurethral electrosurgical resection of prostate, including control of postoperative bleeding, complete (vasectomy, meatotomy, cystourethroscopy, urethral calibration and/or dilation, and internal urethrotomy are included)",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109833,"Laser vaporization of prostate, including control of postoperative bleeding, complete (vasectomy, meatotomy, cystourethroscopy, urethral calibration and/or dilation, internal urethrotomy and transurethral resection of prostate are included if performed)",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109900,"Destruction of lesion(s), penis (eg, condyloma, papilloma, molluscum contagiosum, herpetic vesicle), simple; chemical",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109902,"Destruction of lesion(s), penis (eg, condyloma, papilloma, molluscum contagiosum, herpetic vesicle), simple; cryosurgery",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109905,"Destruction of lesion(s), penis (eg, condyloma, papilloma, molluscum contagiosum, herpetic vesicle), extensive (eg, laser surgery, electrosurgery, cryosurgery, chemosurgery)",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109906,"Biopsy of penis, (separate procedure)",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109916,"Circumcision, using clamp or other device with regional dorsal penile or ring block",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109968,Foreskin manipulation including lysis of preputial adhesions and stretching,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109973,"Orchiectomy, simple (including subcapsular), with or without testicular prosthesis, scrotal or inguinal approach",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2109981,"Orchiopexy, inguinal approach, with or without hernia repair",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110004,Drainage of scrotal wall abscess,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110011,"Vasectomy, unilateral or bilateral (separate procedure), including postoperative semen examination(s)",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110026,"Biopsy, prostate; needle or punch, single or multiple, any approach",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110039,"Prostatectomy, retropubic radical, with or without nerve sparing; with bilateral pelvic lymphadenectomy, including external iliac, hypogastric, and obturator nodes",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110044,"Laparoscopy, surgical prostatectomy, retropubic radical, including nerve sparing, includes robotic assistance, when performed",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110078,Colposcopy of the vulva,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110116,"Colpopexy, vaginal; extra-peritoneal approach (sacrospinous, iliococcygeus)",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110142,"Laparoscopy, surgical, colpopexy (suspension of vaginal apex)",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110144,"Colposcopy of the cervix including upper/adjacent vagina, with biopsy(s) of the cervix and endocervical curettage",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110169,"Endometrial sampling (biopsy) with or without endocervical sampling (biopsy), without cervical dilation, any method (separate procedure)",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110175,"Total abdominal hysterectomy (corpus and cervix), with or without removal of tube(s), with or without removal of ovary(s)",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110194,Insertion of intrauterine device (IUD),,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110195,Removal of intrauterine device (IUD),,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110203,"Endometrial ablation, thermal, without hysteroscopic guidance",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110222,"Hysteroscopy, surgical; with sampling (biopsy) of endometrium and/or polypectomy, with or without D & C",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110227,"Hysteroscopy, surgical; with endometrial ablation (eg, endometrial resection, electrosurgical ablation, thermoablation)",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110230,"Laparoscopy, surgical, with total hysterectomy, for uterus 250 g or less; with removal of tube(s) and/or ovary(s)",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110307,"Routine obstetric care including antepartum care, vaginal delivery (with or without episiotomy, and/or forceps) and postpartum care",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110315,"Routine obstetric care including antepartum care, cesarean delivery, and postpartum care",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110316,Cesarean delivery only,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110317,"Cesarean delivery only, including postpartum care",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2110326,"Treatment of missed abortion, completed surgically; first trimester",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211747,"Ultrasound, pregnant uterus, real time with image documentation, fetal and maternal evaluation, first trimester (< 14 weeks 0 days), transabdominal approach; single or first gestation",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211749,"Ultrasound, pregnant uterus, real time with image documentation, fetal and maternal evaluation, after first trimester (> or = 14 weeks 0 days), transabdominal approach; single or first gestation",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211751,"Ultrasound, pregnant uterus, real time with image documentation, fetal and maternal evaluation plus detailed fetal anatomic examination, transabdominal approach; single or first gestation",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211753,"Ultrasound, pregnant uterus, real time with image documentation, first trimester fetal nuchal translucency measurement, transabdominal or transvaginal approach; single or first gestation",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211755,"Ultrasound, pregnant uterus, real time with image documentation, limited (eg, fetal heart beat, placental location, fetal position and/or qualitative amniotic fluid volume), 1 or more fetuses",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211756,"Ultrasound, pregnant uterus, real time with image documentation, follow-up (eg, re-evaluation of fetal size by measuring standard growth parameters and amniotic fluid volume, re-evaluation of organ system(s) suspected or confirmed to be abnormal on a prev",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211757,"Ultrasound, pregnant uterus, real time with image documentation, transvaginal",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211765,"Ultrasound, transvaginal",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2211769,"Ultrasound, scrotum and contents",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2617204,"Cervical or vaginal cancer screening, pelvic and clinical breast examination",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2721063,"Annual gynecological examination, new patient",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2721064,"Annual gynecological examination, established patient",,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2780478,"Resection of Prostate, Percutaneous Endoscopic Approach",,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,2780523,"Resection of Prepuce, External Approach",,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4005743,Female sterility,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4005933,"Hypospadias, penile",,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4012343,Vaginal discharge symptom,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4016155,Prostatism,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4021531,Total abdominal hysterectomy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4032594,Inflammation of scrotum,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4032622,Laparoscopic supracervical hysterectomy,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4038747,Obstetric examination,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4048225,Neoplasm of endometrium,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4050091,Open wound of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4051956,Vulvovaginal disease,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4052532,Hysteroscopy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4054550,Open wound of scrotum and testes,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4056903,Vaginitis associated with another disorder,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4058792,Douche of vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060207,Vulval irritation,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060556,"Uterine scar from previous surgery in pregnancy, childbirth and the puerperium",,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060558,"Uterine scar from previous surgery in pregnancy, childbirth and the puerperium - delivered",,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4060559,"Uterine scar from previous surgery in pregnancy, childbirth and the puerperium with antenatal problem",,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4061050,Subacute and chronic vaginitis,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4071874,Pain in scrotum,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4073700,Transurethral laser prostatectomy,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4081648,Acute vaginitis,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4083772,Echography of scrotum and contents,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4090039,Penile arterial insufficiency,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4092515,"Malignant neoplasm, overlapping lesion of cervix uteri",,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4093346,Large prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4095940,Finding of pattern of menstrual cycle,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4096783,Radical prostatectomy,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4109081,Pain in penis,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4127886,Hysterectomy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4128329,Menopause present,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4129155,Vaginal bleeding,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4138738,Vaginal hysterectomy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4140828,Acute vulvitis,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4141940,Endometrial ablation,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4143116,Azoospermia,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4146777,Radical abdominal hysterectomy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4147021,"Contusion, scrotum or testis",,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4149084,Vaginitis,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4150042,Vaginal ulcer,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4150816,Bicornuate uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4155529,Mechanical complication of intrauterine contraceptive device,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4156113,Malignant neoplasm of body of uterus,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4161944,Low cervical cesarean section,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4162860,Primary malignant neoplasm of body of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4163261,Malignant tumor of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4171394,Abnormal menstrual cycle,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4171915,Orchitis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4180978,Vulvovaginitis,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4181912,Cone biopsy of cervix,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4194652,Pruritus of vulva,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4199600,Candidal balanitis,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4234536,Transurethral prostatectomy,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4235215,Swelling of testicle,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4238715,Removal of intrauterine device,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4243919,Incision of ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4260520,Balanitis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4270932,Pain in testicle,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4275113,Insertion of intrauterine contraceptive device,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4279913,Primary ovarian failure,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4281030,Secondary malignant neoplasm of right ovary,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4294393,Ulcer of penis,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4294805,Laparoscopic-assisted vaginal hysterectomy,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4295261,Postmenopausal state,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4303258,Bacterial vaginosis,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4306780,Gynecologic examination,,,Female,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4310552,Orchidopexy,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4320332,Hydrocele of tunica vaginalis,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4321575,Lysis of penile adhesions,,,Male,5,,,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4330583,Vasectomy,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,4339088,Testicular mass,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40481080,Benign localized hyperplasia of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40482030,Dysplasia of prostate,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40482406,Low lying placenta,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40483613,Inflammatory disease of female genital structure,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,40490888,Herniation of rectum into vagina,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,42709954,Phimosis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45757415,Benign endometrial hyperplasia,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45766654,Disorder of skin of penis,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45770892,Primary malignant neoplasm of uterus,,,Female,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,45772671,Nodular prostate without urinary obstruction,,,Male,5,,,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,"4090861, 4025213","Male genitalia finding, Male reproductive finding",,,,,Male,2,,,,
+CONDITION_OCCURRENCE,CONDITION_CONCEPT_ID,"4095793 , 443343, 4024004 , 4172857, 444094 , 197810, 4158481","Female genitalia finding, Disorder of intrauterine contraceptive device, Menopause finding, Disorder of female genital system, Malignant neoplasm of uterine adnexa, Finding related to pregnancy, Female reproductive finding",,,,,Female,2,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,4041261,Procedure on female genital system,,,,,Female,2,,,,
+PROCEDURE_OCCURRENCE,PROCEDURE_CONCEPT_ID,"4250917, 4077750, 4043199, 4040577","Operation on prostate, Operation on scrotum, Procedure on penis, Procedure on testis",,,,,Male,2,,,,
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006315,Basophils [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004410,Hemoglobin A1c/Hemoglobin.total in Blood,,,,,,,,"8554,8737,9225,9579",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40487382,Total lymphocyte count,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013721,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019198,Lymphocytes [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034426,Prothrombin time (PT),,,,,,,,8555,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3043688,Hemoglobin [Mass/volume] in Body fluid,,,,,,,,"8713,8859",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3046485,Urea nitrogen/Creatinine [Mass Ratio] in Blood,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4216098,Eosinophil count,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4245152,Potassium measurement,,,,,,,,"8736,8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,43055141,Pain severity - 0-10 verbal numeric rating [Score] - Reported,,,,,,,,-1,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006923,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021044,Iron binding capacity [Mass/volume] in Serum or Plasma,,,,,,,,8837,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024171,Respiratory rate,,,,,,,,"8483,8541",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027114,Cholesterol [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762499,Oxygen saturation in Arterial blood by Pulse oximetry,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000963,Hemoglobin [Mass/volume] in Blood,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001604,Monocytes [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019069,Monocytes/100 leukocytes in Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022509,Hyaline casts [#/area] in Urine sediment by Microscopy low power field,,,,,,,,8765,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028288,Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4148615,Neutrophil count,,,,,,,,"8784,8848,8961,8848,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,44806420,Estimation of glomerular filtration rate,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028437,Cholesterol in LDL [Mass/volume] in Serum or Plasma,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,,,,,,,,8837,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026925,Triiodothyronine (T3) Free [Mass/volume] in Serum or Plasma,,,,,,,,"8820,8845",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3028615,Eosinophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3051205,Crystals [#/area] in Urine sediment by Microscopy high power field,,,,,,,,8786,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4098046,Pulse oximetry,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005131,Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin,,,,,,,,"8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011163,Cholesterol.total/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8529,8554,8596,8606,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3044491,Cholesterol non HDL [Mass/volume] in Serum or Plasma,,,,,,,,"8576,8840,9028",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4017361,Blood urea nitrogen measurement,,,,,,,,"8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006504,Eosinophils/100 leukocytes in Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000483,Glucose [Mass/volume] in Blood,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033543,Specific gravity of Urine,,,,,,,,"8523,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3045716,Anion gap in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4101713,High density lipoprotein cholesterol measurement,,,,,,,,"8636,8736,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4103762,Anion gap measurement,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001008,Epithelial cells.squamous [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8765,8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009744,MCHC [Mass/volume] by Automated count,,,,,,,,"8564,8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013115,Eosinophils [#/volume] in Blood,,,,,,,,"8848,8961,9444,8784,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019550,Sodium [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020416,Erythrocytes [#/volume] in Blood by Automated count,,,,,,,,"44777575,8734,8815,8647,8931,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035995,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3038553,Body mass index (BMI) [Ratio],,,,,,,,9531,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,35610320,Diastolic arterial pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001490,Nucleated erythrocytes [#/volume] in Blood,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4195214,Cholesterol/HDL ratio measurement,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,36306178,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393850,MCHC - Mean corpuscular haemoglobin concentration,,,,,,,,"8636,8713,8554,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004501,Glucose [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008598,Thyroxine (T4) free [Mass/volume] in Serum or Plasma,,,,,,,,"8817,8845,8725",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018010,Neutrophils/100 leukocytes in Blood,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022192,Triglyceride [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151768,Pack years,,,,,,,,"9448,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197602,Serum TSH measurement,,,,,,,,"8719,9040,9093,44777578,8750,8923,44777583",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006906,Calcium [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007070,Cholesterol in HDL [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020460,C reactive protein [Mass/volume] in Serum or Plasma,,,,,,,,"8751,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023314,Hematocrit [Volume Fraction] of Blood by Automated count,,,,,,,,"44777604,8554",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035941,MCH [Entitic mass],,,,,,,,"8564,9655",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037072,Urobilinogen [Mass/volume] in Urine by Test strip,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4151358,Hematocrit determination,,,,,,,,"44777604,8554,8523",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4194332,Monocyte count,,,,,,,,"8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001123,Platelet mean volume [Entitic volume] in Blood,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012888,Diastolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013707,Erythrocyte sedimentation rate by Westergren method,,,,,,,,8752,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037511,Lymphocytes/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3040168,Immature granulocytes [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4097430,Sodium measurement,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3005424,Body surface area,,,,,,,,8617,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013603,Prostate specific Ag [Mass/volume] in Serum or Plasma,,,,,,,,"8748,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020509,Albumin/Globulin [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036277,Body height,,,,,,,,"8582,9327,9330,9546",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4301868,Pulse rate,,,,,,,,"8483,8541,8581",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40762636,Body mass index (BMI) [Percentile],,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40765040,25-Hydroxyvitamin D3+25-Hydroxyvitamin D2 [Mass/volume] in Serum or Plasma,,,,,,,,"8842,8845",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024386,Platelet mean volume [Entitic volume] in Blood by Rees-Ecker,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009201,Thyrotropin [Units/volume] in Serum or Plasma,,,,,,,,"44777578,8719,9040,9093,8860",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024731,MCV [Entitic volume],,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3050479,Immature granulocytes/100 leukocytes in Blood,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4012479,Low density lipoprotein cholesterol measurement,,,,,,,,"8636,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4152194,Systolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393840,Haematocrit,,,,,,,,"44777604,8523,8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,,,,,,,,"8845,8725",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002888,Erythrocyte distribution width [Entitic volume],,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010910,Erythrocytes [#/volume] in Body fluid,,,,,,,,"8647,8785,8815,8931,8784,8848,9257,8888,9428",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013290,Carbon dioxide [Partial pressure] in Blood,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027970,Globulin [Mass/volume] in Serum by calculation,,,,,,,,"8636,8713,8950",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4239408,Heart rate,,,,,,,,"8483,8541,8581",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010813,Leukocytes [#/volume] in Blood,,,,,,,,"44777588,8848,8961,9444,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023103,Potassium [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4030871,Red blood cell count,,,,,,,,"8734,8815,8931,9444,9445",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4154790,Diastolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4217013,Systolic arterial pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001318,Cholesterol.total/Cholesterol in HDL [Percentile],,,,,,,,"8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004249,Systolic blood pressure,,,,,,,,8876,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009596,Cholesterol in VLDL [Mass/volume] in Serum or Plasma by calculation,,,,,,,,"8576,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025315,Body weight,,,,,,,,"8739,9346,9373,9529",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3053283,"Glomerular filtration rate/1.73 sq M.predicted among blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4008265,Total cholesterol measurement,,,,,,,,"8736,8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,36303797,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398460,Serum alkaline phosphatase level,,,,,,,,"32995,8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026361,Erythrocytes [#/volume] in Blood,,,,,,,,"32706,8785,8815,8931,8784,8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3027018,Heart rate,,,,,,,,"8483,8541,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4013965,"Oxygen saturation measurement, arterial",,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013429,Basophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3023599,MCV [Entitic volume] by Automated count,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3036588,Neutrophil cytoplasmic Ab.perinuclear [Presence] in Serum,,,,,,,,"8525,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4298431,White blood cell count,,,,,,,,"8848,8961,9444,8784,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017732,Neutrophils [#/volume] in Blood,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024561,Albumin [Mass/volume] in Serum or Plasma,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034639,Hemoglobin A1c [Mass/volume] in Blood,,,,,,,,"8713,8840,9579,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013650,Neutrophils [#/volume] in Blood by Automated count,,,,,,,,"8784,8848,8961,9444,8647,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3021886,Globulin [Mass/volume] in Serum,,,,,,,,"8636,8713,8950",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4254663,Lymphocyte count,,,,,,,,"8848,9444,8961",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001420,Magnesium [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3007461,Platelets [#/volume] in Blood,,,,,,,,"8848,8961,9444,32706",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3012030,MCH [Entitic mass] by Automated count,,,,,,,,"8564,8704,9655,8504,8576",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40764999,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008893,Testosterone [Mass/volume] in Serum or Plasma,,,,,,,,"8817,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3016723,Creatinine [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8749",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3026910,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,,,,,,,,"8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3033575,Monocytes [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785,8647",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3041084,Immature granulocytes [#/volume] in Blood by Automated count,,,,,,,,"8848,8961,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4184637,Hemoglobin A1c measurement,,,,,,,,"8554,8632,8737,9579",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4313591,Respiratory rate,,,,,,,,"8483,8541",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393851,MCV - Mean corpuscular volume,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,1619025,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (CKD-EPI 2021)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3013869,Basophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035472,Albumin/Protein.total in Serum or Plasma,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3039000,Anion gap in Blood,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000905,Leukocytes [#/volume] in Blood by Automated count,,,,,,,,"8816,8848,8961,9436,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3015632,"Carbon dioxide, total [Moles/volume] in Serum or Plasma",,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3032710,Calcium.ionized/Calcium.total corrected for albumin in Blood,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4197971,HbA1c measurement (DCCT aligned),,,,,,,,"8554,8632,8737",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,42869452,Immature granulocytes/100 leukocytes in Blood by Automated count,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002109,Cholesterol in LDL/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8596,8606,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3004327,Lymphocytes [#/volume] in Blood by Automated count,,,,,,,,"8784,8816,8848,8961,9436,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3006322,Oral temperature,,,,,,,,"586323,9289",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3008342,Neutrophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020630,Protein [Mass/volume] in Serum or Plasma,,,,,,,,"8636,8713",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3001122,Ferritin [Mass/volume] in Serum or Plasma,,,,,,,,"8748,8842",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3009542,Hematocrit [Volume Fraction] of Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010189,Epithelial cells [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8765,8786",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3010457,Eosinophils/100 leukocytes in Blood by Automated count,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4192368,Platelet mean volume determination,,,,,,,,8583,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3014576,Chloride [Moles/volume] in Serum or Plasma,,,,,,,,"8753,9557",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024128,Bilirubin.total [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8749",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3018311,Urea nitrogen/Creatinine [Mass Ratio] in Serum or Plasma,,,,,,,,"8523,8554,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020891,Body temperature,,,,,,,,"586323,9289",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3037556,Urate [Mass/volume] in Serum or Plasma,,,,,,,,"8840,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37399332,Serum TSH (thyroid stimulating hormone) level,,,,,,,,"44777578,9040",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3011904,Phosphate [Mass/volume] in Serum or Plasma,,,,,,,,8840,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019897,Erythrocyte distribution width [Ratio] by Automated count,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3025255,Bacteria [#/area] in Urine sediment by Microscopy high power field,,,,,,,,8786,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4076704,High density lipoprotein measurement,,,,,,,,"8753,8840",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4172647,Basophil count,,,,,,,,"8848,8961,9444,8785",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37393531,Serum alanine aminotransferase level,,,,,,,,"32995,8645,8923",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,40771529,Immature granulocytes/100 leukocytes in Body fluid,,,,,,,,"8554,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3000034,Microalbumin [Mass/volume] in Urine,,,,,,,,"8576,8723,8751,8840,8859,8636",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3035124,Erythrocytes [#/area] in Urine sediment by Microscopy high power field,,,,,,,,"8786,8889",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002030,Lymphocytes/100 leukocytes in Blood,,,,,,,,"8554,8848",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3019170,Thyrotropin [Units/volume] in Serum or Plasma by Detection limit <= 0.005 mIU/L,,,,,,,,"44777578,8719,8860,9040,9093,9550",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3020149,25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma,,,,,,,,8842,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022174,Leukocytes [#/volume] in Body fluid,,,,,,,,"8647,8784,8785,8848,8961,9257,8888",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3024929,Platelets [#/volume] in Blood by Automated count,,,,,,,,"8816,8848,8961,9436,9444",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3049187,"Glomerular filtration rate/1.73 sq M.predicted among non-blacks [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,37398676,Basophil count,,,,,,,,8848,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4112223,BUN/Creatinine ratio,,,,,,,,"8523,8596,-1",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3017250,Creatinine [Mass/volume] in Urine,,,,,,,,"8840,8636",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,4191837,Calculated LDL cholesterol level,,,,,,,,"8840,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3022096,Basophils/100 leukocytes in Blood,,,,,,,,8554,5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3034485,Albumin/Creatinine [Mass Ratio] in Urine,,,,,,,,"8523,8723,8838,9017,9072",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,44790183,Glomerular filtration rate testing,,,,,,,,"720870,8795",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3002400,Iron [Mass/volume] in Serum or Plasma,,,,,,,,"8749,8837",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID
+MEASUREMENT,MEASUREMENT_CONCEPT_ID,3003338,MCHC [Mass/volume],,,,,,,,"8713,8753",5,Approved UNIT_CONCEPT_IDs for the given MEASUREMENT_CONCEPT_ID


### PR DESCRIPTION
Removes the unused thresholds for concept-level checks `plausibleValueLow`, `plausibleValueHigh`, `validPrevalenceLow`, `validPrevalenceHigh` and `isTemporallyConstant`.

This removes 55 rows from the concept-level thresholds file that were not executed, as they only specified one of the deprecated checks above. The columns for these checkNames were also removed, simplifying the file.

Compared before and after, and the same number of concept-level checks are executed (472).

